### PR TITLE
Cardano Shelley Update 2/3

### DIFF
--- a/docs/methods/cardanoGetAddress.md
+++ b/docs/methods/cardanoGetAddress.md
@@ -16,13 +16,23 @@ TrezorConnect.cardanoGetAddress(params).then(function(result) {
 ### Params
 [****Optional common params****](commonParams.md)
 #### Exporting single address
-* `path` — *obligatory* `string | Array<number>` minimum length is `5`. [read more](path.md)
+* `addressParameters` — *obligatory* see description below
 * `address` — *optional* `string` address for validation (read `Handle button request` section below)
-* `protocolMagic` - *obligatory* `Integer` 0 for Mainnet, 42 for Testnet
+* `protocolMagic` - *obligatory* `Integer` 764824073 for Mainnet, 42 for Testnet
+* `networkId` - *obligatory* `Integer` 1 for Mainnet, 0 for Testnet
 * `showOnTrezor` — *optional* `boolean` determines if address will be displayed on device. Default is set to `true`
 
 #### Exporting bundle of addresses
-* `bundle` - `Array` of Objects with `path` and `showOnTrezor` fields
+* `bundle` - `Array` of Objects with single address fields
+
+#### Address Parameters
+###### [flowtype](../../src/js/types/networks/cardano.js#L37-L43)
+* `addressType` - *obligatory* `CardanoAddressType`/`number` - you can use the flow `CARDANO_ADDRESS_TYPE` object or typescript `CardanoAddressType` enum
+* `path` — *obligatory* `string | Array<number>` minimum length is `5`. [read more](path.md)
+* `stakingPath` — *optional* `string | Array<number>` minimum length is `5`. [read more](path.md) Used for base address derivation
+* `stakingKeyHash` - *optional* `string` hex string of staking key hash. Used for base address derivation (as an alternative to `stakingPath`)
+* `certificatePointer` - *optional* `CardanoCertificatePointer` object. Must contain `number`s `blockIndex`, `txIndex` and `certificateIndex`. ([flowtype](../../src/js/types/networks/cardano.js#L31-L35)) Used for pointer address derivation. [read more about pointer address](https://hydra.iohk.io/build/2006688/download/1/delegation_design_spec.pdf#subsubsection.3.2.2)
+
 
 #### Handle button request
 Since trezor-connect@6.0.4 there is a possibility to handle `UI.ADDRESS_VALIDATION` event which will be triggered once the address is displayed on the device.
@@ -38,21 +48,80 @@ If certain conditions are fulfilled popup will not be used at all:
 
 
 ### Example
-Display address of first cardano account:
+Display byron address of first cardano account:
 ```javascript
 TrezorConnect.cardanoGetAddress({
-    path: "m/44'/1815'/0'/0/0",
-    protocolMagic: 0,
+    addressParameters: {
+        addressType: 8,
+        path: "m/44'/1815'/0'/0/0",
+    },
+    protocolMagic: 764824073,
+    networkId: 1,
+});
+```
+Display base address of first cardano account:
+```javascript
+TrezorConnect.cardanoGetAddress({
+    addressParameters: {
+        addressType: 0,
+        path: "m/1852'/1815'/0'/0/0",
+        stakingPath: "m/1852'/1815'/0'/2/0",
+    },
+    protocolMagic: 764824073,
+    networkId: 1,
+});
+```
+Display pointer address of first cardano account:
+```javascript
+TrezorConnect.cardanoGetAddress({
+    addressParameters: {
+        addressType: 4,
+        path: "m/1852'/1815'/0'/0/0",
+        certificatePointer: {
+            blockIndex: 1,
+            txIndex: 2,
+            certificateIndex: 3,
+        },
+    },
+    protocolMagic: 764824073,
+    networkId: 1,
 });
 ```
 Return a bundle of cardano addresses without displaying them on device:
 ```javascript
 TrezorConnect.cardanoGetAddress({
     bundle: [
-        { path: "m/44'/1815'/0'/0/0", protocolMagic: 0, showOnTrezor: false }, // account 1, address 1
-        { path: "m/44'/1815'/1'/0/1", protocolMagic: 0, showOnTrezor: false }, // account 2, address 2
-        { path: "m/44'/1815'/2'/0/2", protocolMagic: 0, showOnTrezor: false }  // account 3, address 3
-        { path: "m/44'/1815'/0'/0/0", protocolMagic: 42, showOnTrezor: false }  // account 1, address 0, testnet
+        // byron address, account 1, address 1
+        {
+            addressParameters: {
+                addressType: 8,
+                path: "m/44'/1815'/0'/0/0",
+            },
+            protocolMagic: 764824073,
+            networkId: 1,
+            showOnTrezor: false
+        },
+        // base address with staking key hash, account 1, address 1
+        {
+            addressParameters: {
+                addressType: 0,
+                path: "m/1852'/1815'/0'/0/0",
+                stakingKeyHash: '1bc428e4720702ebd5dab4fb175324c192dc9bb76cc5da956e3c8dff',
+            },
+            protocolMagic: 764824073,
+            networkId: 1,
+            showOnTrezor: false
+        },
+        // byron address, account 2, address 3, testnet
+        {
+            addressParameters: {
+                addressType: 8,
+                path: "m/44'/1815'/1'/0/2",
+            },
+            protocolMagic: 42,
+            networkId: 0,
+            showOnTrezor: false
+        },
     ]
 });
 ```
@@ -66,8 +135,12 @@ TrezorConnect.on(UI.ADDRESS_VALIDATION, data => {
 });
 
 const result = await TrezorConnect.cardanoGetAddress({
-    path: "m/44'/1815'/0'/0/0",
-    protocolMagic: 0,
+    addressParameters: {
+        addressType: 8,
+        path: "m/44'/1815'/0'/0/0",
+    },
+    protocolMagic: 764824073,
+    networkId: 0,
     address: "Ae2tdPwUPEZ5YUb8sM3eS8JqKgrRLzhiu71crfuH2MFtqaYr5ACNRdsswsZ",
 });
 // dont forget to hide your custom UI after you get the result!
@@ -79,9 +152,21 @@ Result with only one address
 {
     success: true,
     payload: {
-        path: Array<number>, // hardended path
+        addressParameters: {
+            addressType: number,
+            path: Array<number>, // hardend path
+            stakingPath?: Array<number>, // hardend path
+            stakingKeyHash?: string,
+            certificatePointer?: {
+                blockIndex: number,
+                txIndex: number,
+                certificatePointer: number,
+            }
+        }
         serializedPath: string,
+        serializedStakingPath?: string,
         protocolMagic: number,
+        networkId: number,
         address: string,
     }
 }
@@ -91,9 +176,60 @@ Result with bundle of addresses
 {
     success: true,
     payload: [
-        { path: Array<number>, serializedPath: string, protocolMagic: number, address: string }, // account 1, address 1
-        { path: Array<number>, serializedPath: string, protocolMagic: number, address: string }, // account 2, address 2
-        { path: Array<number>, serializedPath: string, protocolMagic: number, address: string }  // account 3, address 3
+        {
+            addressParameters: {
+                addressType: number,
+                path: Array<number>, // hardend path
+                stakingPath?: Array<number>, // hardend path
+                stakingKeyHash?: string,
+                certificatePointer?: {
+                    blockIndex: number,
+                    txIndex: number,
+                    certificatePointer: number,
+                }
+            }
+            serializedPath: string,
+            serializedStakingPath?: string,
+            protocolMagic: number,
+            networkId: number,
+            address: string,
+        },
+        {
+            addressParameters: {
+                addressType: number,
+                path: Array<number>, // hardend path
+                stakingPath?: Array<number>, // hardend path
+                stakingKeyHash?: string,
+                certificatePointer?: {
+                    blockIndex: number,
+                    txIndex: number,
+                    certificatePointer: number,
+                }
+            }
+            serializedPath: string,
+            serializedStakingPath?: string,
+            protocolMagic: number,
+            networkId: number,
+            address: string,
+        },
+        {
+            addressParameters: {
+                addressType: number,
+                path: Array<number>, // hardend path
+                stakingPath?: Array<number>, // hardend path
+                stakingKeyHash?: string,
+                certificatePointer?: {
+                    blockIndex: number,
+                    txIndex: number,
+                    certificatePointer: number,
+                }
+            }
+            serializedPath: string,
+            serializedStakingPath?: string,
+            protocolMagic: number,
+            networkId: number,
+            address: string,
+        },
     ]
 }
 ```

--- a/docs/methods/cardanoSignTransaction.md
+++ b/docs/methods/cardanoSignTransaction.md
@@ -17,12 +17,13 @@ TrezorConnect.cardanoSignTransaction(params).then(function(result) {
 
 ### Params 
 [****Optional common params****](commonParams.md)
-###### [flowtype](../../src/js/types/networks/cardano.js#L38-L57)
-* `inputs` — *obligatory* `Array` of [CardanoInput](../../src/js/types/networks/cardano.js#L38)
-* `outputs` - *obligatory* `Array` of [CardanoOutput](../../src/js/types/networks/cardano.js#L43)
+###### [flowtype](../../src/js/types/networks/cardano.js#L62-L90)
+* `inputs` — *obligatory* `Array` of [CardanoInput](../../src/js/types/networks/cardano.js#L64)
+* `outputs` - *obligatory* `Array` of [CardanoOutput](../../src/js/types/networks/cardano.js#L69)
 * `fee` - *obligatory* `String`
 * `ttl` - *obligatory* `String`
-* `protocolMagic` - *obligatory* `Integer` 0 for Mainnet, 42 for Testnet
+* `protocolMagic` - *obligatory* `Integer` 764824073 for Mainnet, 42 for Testnet
+* `networkId` - *obligatory* `Integer` 1 for Mainnet, 0 for Testnet
 
 ### Example
 ```javascript
@@ -37,21 +38,26 @@ TrezorConnect.cardanoSignTransaction({
     outputs: [
         {
             address: "Ae2tdPwUPEZCanmBz5g2GEwFqKTKpNJcGYPKfDxoNeKZ8bRHr8366kseiK2",
-            amount: "3003112"
+            amount: "3003112",
         },
         {
-            path: "m/44'/1815'/0'/0/1",
-            amount: "7120787"
+            addressParameters: {
+                addressType: 0,
+                path: "m/1852'/1815'/0'/0/0",
+                stakingPath: "m/1852'/1815'/0'/2/0",
+            },
+            amount: "7120787",
         }
     ],
     fee: "42",
     ttl: "10",
-    protocolMagic: 0
+    protocolMagic: 764824073,
+    networkId: 1,
 });
 ```
 
 ### Result
-###### [flowtype](../../src/js/types/networks/cardano.js#L59-L62)
+###### [flowtype](../../src/js/types/networks/cardano.js#L86-L89)
 ```javascript
 {
     success: true,

--- a/src/__tests__/core/cardanoGetAddress.spec.js
+++ b/src/__tests__/core/cardanoGetAddress.spec.js
@@ -1,5 +1,6 @@
 /* @flow */
 import type { CardanoGetAddress } from '../../js/types';
+import { CARDANO_ADDRESS_TYPE } from '../../js/types';
 
 // vectors from https://github.com/trezor/trezor-firmware/tree/master/python/trezorlib/tests/device_tests/test_msg_cardano_get_address.py
 
@@ -8,97 +9,346 @@ const PROTOCOL_MAGICS = {
     testnet: 42,
 };
 
-const getAddressMainnet = () => {
+const NETWORK_IDS = {
+    mainnet: 1,
+    testnet: 0,
+};
+
+const HARDENED = 0x80000000;
+
+const getByronAddressMainnet = () => {
     const testPayloads: CardanoGetAddress[] = [
         {
             method: 'cardanoGetAddress',
-            path: "m/44'/1815'/0'/0/0",
+            addressParameters: {
+                addressType: CARDANO_ADDRESS_TYPE.Byron,
+                path: "m/44'/1815'/0'/0/0",
+            },
             protocolMagic: PROTOCOL_MAGICS['mainnet'],
+            networkId: NETWORK_IDS['mainnet'],
         },
         {
             method: 'cardanoGetAddress',
-            path: [2147483697],
+            addressParameters: {
+                addressType: CARDANO_ADDRESS_TYPE.Byron,
+                path: [HARDENED + 49],
+            },
             protocolMagic: PROTOCOL_MAGICS['mainnet'],
+            networkId: NETWORK_IDS['mainnet'],
         },
         {
             method: 'cardanoGetAddress',
-            path: "m/44'/1815'/0'/0/1",
+            addressParameters: {
+                addressType: CARDANO_ADDRESS_TYPE.Byron,
+                path: "m/44'/1815'/0'/0/1",
+            },
             protocolMagic: PROTOCOL_MAGICS['mainnet'],
+            networkId: NETWORK_IDS['mainnet'],
         },
         {
             method: 'cardanoGetAddress',
-            path: "m/44'/1815'/0'/0/2",
+            addressParameters: {
+                addressType: CARDANO_ADDRESS_TYPE.Byron,
+                path: "m/44'/1815'/0'/0/2",
+            },
             protocolMagic: PROTOCOL_MAGICS['mainnet'],
+            networkId: NETWORK_IDS['mainnet'],
         },
     ];
 
     const expectedResponses = [
         {
             payload: {
-                address: 'Ae2tdPwUPEZLCq3sFv4wVYxwqjMH2nUzBVt1HFr4v87snYrtYq3d3bq2PUQ',
+                address: 'Ae2tdPwUPEZ5YUb8sM3eS8JqKgrRLzhiu71crfuH2MFtqaYr5ACNRdsswsZ',
             },
         },
         { success: false },
         {
             payload: {
-                address: 'Ae2tdPwUPEZEY6pVJoyuNNdLp7VbMB7U7qfebeJ7XGunk5Z2eHarkcN1bHK',
+                address: 'Ae2tdPwUPEZJb8r1VZxweSwHDTYtqeYqF39rZmVbrNK62JHd4Wd7Ytsc8eG',
             },
         },
         {
             payload: {
-                address: 'Ae2tdPwUPEZ3gZD1QeUHvAqadAV59Zid6NP9VCR9BG5LLAja9YtBUgr6ttK',
+                address: 'Ae2tdPwUPEZFm6Y7aPZGKMyMAK16yA5pWWKU9g73ncUQNZsAjzjhszenCsq',
             },
         },
     ];
 
     return {
         testName: 'CardanoGetAddress',
-        mnemonic: 'mnemonic_12',
+        mnemonic: 'mnemonic_all',
         testPayloads,
         expectedResponses,
     };
 };
 
-const getAddressTestnet = () => {
+const getByronAddressTestnet = () => {
     const testPayloads: CardanoGetAddress[] = [
         {
             method: 'cardanoGetAddress',
-            path: "m/44'/1815'/0'/0/0",
+            addressParameters: {
+                addressType: CARDANO_ADDRESS_TYPE.Byron,
+                path: "m/44'/1815'/0'/0/0",
+            },
             protocolMagic: PROTOCOL_MAGICS['testnet'],
+            networkId: NETWORK_IDS['testnet'],
         },
         {
             method: 'cardanoGetAddress',
-            path: "m/44'/1815'/0'/0/1",
+            addressParameters: {
+                addressType: CARDANO_ADDRESS_TYPE.Byron,
+                path: "m/44'/1815'/0'/0/1",
+            },
             protocolMagic: PROTOCOL_MAGICS['testnet'],
+            networkId: NETWORK_IDS['testnet'],
         },
         {
             method: 'cardanoGetAddress',
-            path: "m/44'/1815'/0'/0/2",
+            addressParameters: {
+                addressType: CARDANO_ADDRESS_TYPE.Byron,
+                path: "m/44'/1815'/0'/0/2",
+            },
             protocolMagic: PROTOCOL_MAGICS['testnet'],
+            networkId: NETWORK_IDS['testnet'],
         },
     ];
 
     const expectedResponses = [
         {
             payload: {
-                address: '2657WMsDfac5vydkak9a7BqGrsLqBzB7K3vT55rucZKYDmVnUCf6hXAFkZSTcUx7r',
+                address: '2657WMsDfac5F3zbgs9BwNWx3dhGAJERkAL93gPa68NJ2i8mbCHm2pLUHWSj8Mfea',
             },
         },
         {
             payload: {
-                address: '2657WMsDfac61ebUDw53WUX49Dcfya8S8G7iYbhN4nP8JSFuh38T1LuFax1bUnhxA',
+                address: '2657WMsDfac6ezKWszxLFqJjSUgpg9NgxKc1koqi24sVpRaPhiwMaExk4useKn5HA',
             },
         },
         {
             payload: {
-                address: '2657WMsDfac5PMpEsxc1md3pgZKUZRZ11MUK8tjkDHBQG9b3TMBsTQc4PmmumVrcn',
+                address: '2657WMsDfac7hr1ioJGr6g7r6JRx4r1My8Rj91tcPTeVjJDpfBYKURrPG2zVLx2Sq',
             },
         },
     ];
 
     return {
         testName: 'CardanoGetAddress',
-        mnemonic: 'mnemonic_12',
+        mnemonic: 'mnemonic_all',
+        testPayloads,
+        expectedResponses,
+    };
+};
+
+const getBaseAddress = () => {
+    const testPayloads: CardanoGetAddress[] = [
+        {
+            method: 'cardanoGetAddress',
+            addressParameters: {
+                addressType: CARDANO_ADDRESS_TYPE.Base,
+                path: "m/1852'/1815'/4'/0/0",
+                stakingPath: "m/1852'/1815'/4'/2/0",
+            },
+            protocolMagic: PROTOCOL_MAGICS['mainnet'],
+            networkId: NETWORK_IDS['mainnet'],
+        },
+        {
+            method: 'cardanoGetAddress',
+            addressParameters: {
+                addressType: CARDANO_ADDRESS_TYPE.Base,
+                path: "m/1852'/1815'/4'/0/0",
+                stakingPath: "m/1852'/1815'/4'/2/0",
+            },
+            protocolMagic: PROTOCOL_MAGICS['testnet'],
+            networkId: NETWORK_IDS['testnet'],
+        },
+        {
+            method: 'cardanoGetAddress',
+            addressParameters: {
+                addressType: CARDANO_ADDRESS_TYPE.Base,
+                path: "m/1852'/1815'/4'/0/0",
+                stakingKeyHash: '1bc428e4720702ebd5dab4fb175324c192dc9bb76cc5da956e3c8dff',
+            },
+            protocolMagic: PROTOCOL_MAGICS['mainnet'],
+            networkId: NETWORK_IDS['mainnet'],
+        },
+        {
+            method: 'cardanoGetAddress',
+            addressParameters: {
+                addressType: CARDANO_ADDRESS_TYPE.Base,
+                path: "m/1852'/1815'/4'/0/0",
+                stakingKeyHash: '1bc428e4720702ebd5dab4fb175324c192dc9bb76cc5da956e3c8dff',
+            },
+            protocolMagic: PROTOCOL_MAGICS['testnet'],
+            networkId: NETWORK_IDS['testnet'],
+        },
+    ];
+
+    const expectedResponses = [
+        {
+            payload: {
+                address: 'addr1q8v42wjda8r6mpfj40d36znlgfdcqp7jtj03ah8skh6u8wnrqua2vw243tmjfjt0h5wsru6appuz8c0pfd75ur7myyeqsx9990',
+            },
+        },
+        {
+            payload: {
+                address: 'addr_test1qrv42wjda8r6mpfj40d36znlgfdcqp7jtj03ah8skh6u8wnrqua2vw243tmjfjt0h5wsru6appuz8c0pfd75ur7myyeqnsc9fs',
+            },
+        },
+        {
+            payload: {
+                address: 'addr1q8v42wjda8r6mpfj40d36znlgfdcqp7jtj03ah8skh6u8wsmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlsydc62k',
+            },
+        },
+        {
+            payload: {
+                address: 'addr_test1qrv42wjda8r6mpfj40d36znlgfdcqp7jtj03ah8skh6u8wsmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hls8m96xf',
+            },
+        },
+    ];
+
+    return {
+        testName: 'CardanoGetAddress',
+        mnemonic: 'mnemonic_all',
+        testPayloads,
+        expectedResponses,
+    };
+};
+
+const getEnterpriseAddress = () => {
+    const testPayloads: CardanoGetAddress[] = [
+        {
+            method: 'cardanoGetAddress',
+            addressParameters: {
+                addressType: CARDANO_ADDRESS_TYPE.Enterprise,
+                path: "m/1852'/1815'/0'/0/0",
+            },
+            protocolMagic: PROTOCOL_MAGICS['mainnet'],
+            networkId: NETWORK_IDS['mainnet'],
+        },
+        {
+            method: 'cardanoGetAddress',
+            addressParameters: {
+                addressType: CARDANO_ADDRESS_TYPE.Enterprise,
+                path: "m/1852'/1815'/0'/0/0",
+            },
+            protocolMagic: PROTOCOL_MAGICS['testnet'],
+            networkId: NETWORK_IDS['testnet'],
+        },
+    ];
+
+    const expectedResponses = [
+        {
+            payload: {
+                address: 'addr1vxq0nckg3ekgzuqg7w5p9mvgnd9ym28qh5grlph8xd2z92su77c6m',
+            },
+        },
+        {
+            payload: {
+                address: 'addr_test1vzq0nckg3ekgzuqg7w5p9mvgnd9ym28qh5grlph8xd2z92s8k2y47',
+            },
+        },
+    ];
+
+    return {
+        testName: 'CardanoGetAddress',
+        mnemonic: 'mnemonic_all',
+        testPayloads,
+        expectedResponses,
+    };
+};
+
+const getPointerAddress = () => {
+    const testPayloads: CardanoGetAddress[] = [
+        {
+            method: 'cardanoGetAddress',
+            addressParameters: {
+                addressType: CARDANO_ADDRESS_TYPE.Pointer,
+                path: "m/1852'/1815'/0'/0/0",
+                certificatePointer: {
+                    blockIndex: 1,
+                    txIndex: 2,
+                    certificateIndex: 3,
+                },
+            },
+            protocolMagic: PROTOCOL_MAGICS['mainnet'],
+            networkId: NETWORK_IDS['mainnet'],
+        },
+        {
+            method: 'cardanoGetAddress',
+            addressParameters: {
+                addressType: CARDANO_ADDRESS_TYPE.Pointer,
+                path: "m/1852'/1815'/0'/0/0",
+                certificatePointer: {
+                    blockIndex: 24157,
+                    txIndex: 177,
+                    certificateIndex: 42,
+                },
+            },
+            protocolMagic: PROTOCOL_MAGICS['testnet'],
+            networkId: NETWORK_IDS['testnet'],
+        },
+    ];
+
+    const expectedResponses = [
+        {
+            payload: {
+                address: 'addr1gxq0nckg3ekgzuqg7w5p9mvgnd9ym28qh5grlph8xd2z92spqgpsl97q83',
+            },
+        },
+        {
+            payload: {
+                address: 'addr_test1gzq0nckg3ekgzuqg7w5p9mvgnd9ym28qh5grlph8xd2z925ph3wczvf2ag2x9t',
+            },
+        },
+    ];
+
+    return {
+        testName: 'CardanoGetAddress',
+        mnemonic: 'mnemonic_all',
+        testPayloads,
+        expectedResponses,
+    };
+};
+
+const getRewardAddress = () => {
+    const testPayloads: CardanoGetAddress[] = [
+        {
+            method: 'cardanoGetAddress',
+            addressParameters: {
+                addressType: CARDANO_ADDRESS_TYPE.Reward,
+                path: "m/1852'/1815'/0'/2/0",
+            },
+            protocolMagic: PROTOCOL_MAGICS['mainnet'],
+            networkId: NETWORK_IDS['mainnet'],
+        },
+        {
+            method: 'cardanoGetAddress',
+            addressParameters: {
+                addressType: CARDANO_ADDRESS_TYPE.Reward,
+                path: "m/1852'/1815'/0'/2/0",
+            },
+            protocolMagic: PROTOCOL_MAGICS['testnet'],
+            networkId: NETWORK_IDS['testnet'],
+        },
+    ];
+
+    const expectedResponses = [
+        {
+            payload: {
+                address: 'stake1uyfz49rtntfa9h0s98f6s28sg69weemgjhc4e8hm66d5yacalmqha',
+            },
+        },
+        {
+            payload: {
+                address: 'stake_test1uqfz49rtntfa9h0s98f6s28sg69weemgjhc4e8hm66d5yac643znq',
+            },
+        },
+    ];
+
+    return {
+        testName: 'CardanoGetAddress',
+        mnemonic: 'mnemonic_all',
         testPayloads,
         expectedResponses,
     };
@@ -106,8 +356,12 @@ const getAddressTestnet = () => {
 
 export const cardanoGetAddress = () => {
     const availableSubtests = {
-        getAddressMainnet,
-        getAddressTestnet,
+        getByronAddressMainnet,
+        getByronAddressTestnet,
+        getBaseAddress,
+        getEnterpriseAddress,
+        getPointerAddress,
+        getRewardAddress,
     };
     return {
         testName: 'CardanoGetAddress',

--- a/src/__tests__/core/cardanoSignTransaction.spec.js
+++ b/src/__tests__/core/cardanoSignTransaction.spec.js
@@ -1,23 +1,84 @@
 /* @flow */
 import type { CardanoSignTransaction } from '../../js/types';
+import { CARDANO_ADDRESS_TYPE } from '../../js/types';
 
 // vectors from https://github.com/trezor/trezor-firmware/tree/master/python/trezorlib/tests/device_tests/test_msg_cardano_sign_transaction.py
 
-const SAMPLE_INPUT = {
-    path: "m/44'/1815'/0'/0/1",
-    prev_hash: '1af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc',
-    prev_index: 0,
+const SAMPLE_INPUTS = {
+    byron_input: {
+        path: "m/44'/1815'/0'/0/1",
+        prev_hash: '1af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc',
+        prev_index: 0,
+    },
+    shelley_input: {
+        path: "m/1852'/1815'/0'/0/0",
+        prev_hash: '3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7',
+        prev_index: 0,
+    },
 };
 
 const SAMPLE_OUTPUTS = {
-    simple_output: {
+    simple_byron_output: {
         address: 'Ae2tdPwUPEZCanmBz5g2GEwFqKTKpNJcGYPKfDxoNeKZ8bRHr8366kseiK2',
         amount: '3003112',
     },
-    change_output: {path: "m/44'/1815'/0'/0/1", amount: '1000000'},
+    byron_change_output: {
+        addressParameters: {
+            addressType: CARDANO_ADDRESS_TYPE.Byron,
+            path: "m/44'/1815'/0'/0/1",
+        },
+        amount: '1000000',
+    },
+    simple_shelley_output: {
+        address: 'addr1q84sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlsd5tq5r',
+        amount: '1',
+    },
+    base_address_with_script_output: {
+        address: 'addr1z90z7zqwhya6mpk5q929ur897g3pp9kkgalpreny8y304r2dcrtx0sf3dluyu4erzr3xtmdnzvcyfzekkuteu2xagx0qeva0pr',
+        amount: '7120787',
+    },
+    base_address_change_output: {
+        addressParameters: {
+            addressType: CARDANO_ADDRESS_TYPE.Base,
+            path: "m/1852'/1815'/0'/0/0",
+            stakingPath: "m/1852'/1815'/0'/2/0",
+        },
+        amount: '7120787',
+    },
+    staking_key_hash_output: {
+        addressParameters: {
+            addressType: CARDANO_ADDRESS_TYPE.Base,
+            path: "m/1852'/1815'/0'/0/0",
+            stakingKeyHash: '32c728d3861e164cab28cb8f006448139c8f1740ffb8e7aa9e5232dc',
+        },
+        amount: '7120787',
+    },
+    pointer_address_output: {
+        addressParameters: {
+            addressType: CARDANO_ADDRESS_TYPE.Pointer,
+            path: "m/1852'/1815'/0'/0/0",
+            certificatePointer: {
+                blockIndex: 1,
+                txIndex: 2,
+                certificateIndex: 3,
+            },
+        },
+        amount: '7120787',
+    },
+    enterprise_address_output: {
+        addressParameters: {
+            addressType: CARDANO_ADDRESS_TYPE.Enterprise,
+            path: "m/1852'/1815'/0'/0/0",
+        },
+        amount: '7120787',
+    },
     testnet_output: {
         address: '2657WMsDfac7BteXkJq5Jzdog4h47fPbkwUM49isuWbYAr2cFRHa3rURP236h9PBe',
         amount: '3003112',
+    },
+    shelley_testnet_output: {
+        address: 'addr_test1vr9s8py7y68e3x66sscs0wkhlg5ssfrfs65084jrlrqcfqqtmut0e',
+        amount: '1',
     },
 };
 
@@ -25,16 +86,21 @@ const FEE = '42';
 const TTL = '10';
 
 const PROTOCOL_MAGICS = {
-    mainnet: 0,
+    mainnet: 764824073,
     testnet: 42,
+};
+
+const NETWORK_IDS = {
+    mainnet: 1,
+    testnet: 0,
 };
 
 const signMainnetNoChange = () => {
     const inputs = [
-        SAMPLE_INPUT,
+        SAMPLE_INPUTS['byron_input'],
     ];
     const outputs = [
-        SAMPLE_OUTPUTS['simple_output'],
+        SAMPLE_OUTPUTS['simple_byron_output'],
     ];
 
     const testPayloads: CardanoSignTransaction[] = [
@@ -45,6 +111,7 @@ const signMainnetNoChange = () => {
             fee: FEE,
             ttl: TTL,
             protocolMagic: PROTOCOL_MAGICS['mainnet'],
+            networkId: NETWORK_IDS['mainnet'],
         },
     ];
 
@@ -66,11 +133,11 @@ const signMainnetNoChange = () => {
 
 const signMainnetChange = () => {
     const inputs = [
-        SAMPLE_INPUT,
+        SAMPLE_INPUTS['byron_input'],
     ];
     const outputs = [
-        SAMPLE_OUTPUTS['simple_output'],
-        SAMPLE_OUTPUTS['change_output'],
+        SAMPLE_OUTPUTS['simple_byron_output'],
+        SAMPLE_OUTPUTS['byron_change_output'],
     ];
 
     const testPayloads: CardanoSignTransaction[] = [
@@ -81,6 +148,7 @@ const signMainnetChange = () => {
             fee: FEE,
             ttl: TTL,
             protocolMagic: PROTOCOL_MAGICS['mainnet'],
+            networkId: NETWORK_IDS['mainnet'],
         },
     ];
 
@@ -100,13 +168,162 @@ const signMainnetChange = () => {
     };
 };
 
+const signMainnetBaseAddress = () => {
+    const inputs = [
+        SAMPLE_INPUTS['shelley_input'],
+    ];
+    const outputs = [
+        SAMPLE_OUTPUTS['simple_shelley_output'],
+        SAMPLE_OUTPUTS['base_address_change_output'],
+    ];
+
+    const testPayloads: CardanoSignTransaction[] = [
+        {
+            method: 'cardanoSignTransaction',
+            inputs,
+            outputs,
+            fee: FEE,
+            ttl: TTL,
+            protocolMagic: PROTOCOL_MAGICS['mainnet'],
+            networkId: NETWORK_IDS['mainnet'],
+        },
+    ];
+
+    const expectedResponses = [
+        {
+            payload: {
+                hash: '16fe72bb198be423677577e6326f1f648ec5fc11263b072006382d8125a6edda',
+                serializedTx: '83a400818258203b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b700018282583901eb0baa5e570cffbe2934db29df0b6a3d7c0430ee65d4c3a7ab2fefb91bc428e4720702ebd5dab4fb175324c192dc9bb76cc5da956e3c8dff018258390180f9e2c88e6c817008f3a812ed889b4a4da8e0bd103f86e7335422aa122a946b9ad3d2ddf029d3a828f0468aece76895f15c9efbd69b42771a006ca79302182a030aa100818258205d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c158406a78f07836dcf4a303448d2b16b217265a9226be3984a69a04dba5d04f4dbb2a47b5e1cbb345f474c0b9634a2f37b921ab26e6a65d5dfd015dacb4455fb8430af6',
+            },
+        },
+    ];
+
+    return {
+        testPayloads,
+        expectedResponses,
+        specName: '/signMainnetTx',
+    };
+};
+
+const signMainnetBaseHashAddress = () => {
+    const inputs = [
+        SAMPLE_INPUTS['shelley_input'],
+    ];
+    const outputs = [
+        SAMPLE_OUTPUTS['simple_shelley_output'],
+        SAMPLE_OUTPUTS['staking_key_hash_output'],
+    ];
+
+    const testPayloads: CardanoSignTransaction[] = [
+        {
+            method: 'cardanoSignTransaction',
+            inputs,
+            outputs,
+            fee: FEE,
+            ttl: TTL,
+            protocolMagic: PROTOCOL_MAGICS['mainnet'],
+            networkId: NETWORK_IDS['mainnet'],
+        },
+    ];
+
+    const expectedResponses = [
+        {
+            payload: {
+                hash: 'd1610bb89bece22ed3158738bc1fbb31c6af0685053e2993361e3380f49afad9',
+                serializedTx: '83a400818258203b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b700018282583901eb0baa5e570cffbe2934db29df0b6a3d7c0430ee65d4c3a7ab2fefb91bc428e4720702ebd5dab4fb175324c192dc9bb76cc5da956e3c8dff018258390180f9e2c88e6c817008f3a812ed889b4a4da8e0bd103f86e7335422aa32c728d3861e164cab28cb8f006448139c8f1740ffb8e7aa9e5232dc1a006ca79302182a030aa100818258205d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c15840622f22d03bc9651ddc5eb2f5dc709ac4240a64d2b78c70355dd62106543c407d56e8134c4df7884ba67c8a1b5c706fc021df5c4d0ff37385c30572e73c727d00f6',
+            },
+        },
+    ];
+
+    return {
+        testPayloads,
+        expectedResponses,
+        specName: '/signMainnetTx',
+    };
+};
+
+const signMainnetPointerAddress = () => {
+    const inputs = [
+        SAMPLE_INPUTS['shelley_input'],
+    ];
+    const outputs = [
+        SAMPLE_OUTPUTS['simple_shelley_output'],
+        SAMPLE_OUTPUTS['pointer_address_output'],
+    ];
+
+    const testPayloads: CardanoSignTransaction[] = [
+        {
+            method: 'cardanoSignTransaction',
+            inputs,
+            outputs,
+            fee: FEE,
+            ttl: TTL,
+            protocolMagic: PROTOCOL_MAGICS['mainnet'],
+            networkId: NETWORK_IDS['mainnet'],
+        },
+    ];
+
+    const expectedResponses = [
+        {
+            payload: {
+                hash: '40535fa8f88515f1da008d3cdf544cf9dbf1675c3cb0adb13b74b9293f1b7096',
+                serializedTx: '83a400818258203b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b700018282583901eb0baa5e570cffbe2934db29df0b6a3d7c0430ee65d4c3a7ab2fefb91bc428e4720702ebd5dab4fb175324c192dc9bb76cc5da956e3c8dff018258204180f9e2c88e6c817008f3a812ed889b4a4da8e0bd103f86e7335422aa0102031a006ca79302182a030aa100818258205d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c15840dbbf050cc13d0696b1884113613318a275e6f0f8c7cb3e7828c4f2f3c158b2622a5d65ea247f1eed758a0f6242a52060c319d6f37c8460f5d14be24456cd0b08f6',
+            },
+        },
+    ];
+
+    return {
+        testPayloads,
+        expectedResponses,
+        specName: '/signMainnetTx',
+    };
+};
+
+const signMainnetEnterpriseAddress = () => {
+    const inputs = [
+        SAMPLE_INPUTS['shelley_input'],
+    ];
+    const outputs = [
+        SAMPLE_OUTPUTS['simple_shelley_output'],
+        SAMPLE_OUTPUTS['enterprise_address_output'],
+    ];
+
+    const testPayloads: CardanoSignTransaction[] = [
+        {
+            method: 'cardanoSignTransaction',
+            inputs,
+            outputs,
+            fee: FEE,
+            ttl: TTL,
+            protocolMagic: PROTOCOL_MAGICS['mainnet'],
+            networkId: NETWORK_IDS['mainnet'],
+        },
+    ];
+
+    const expectedResponses = [
+        {
+            payload: {
+                hash: 'd3570557b197604109481a80aeb66cd2cfabc57f802ad593bacc12eb658e5d72',
+                serializedTx: '83a400818258203b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b700018282583901eb0baa5e570cffbe2934db29df0b6a3d7c0430ee65d4c3a7ab2fefb91bc428e4720702ebd5dab4fb175324c192dc9bb76cc5da956e3c8dff0182581d6180f9e2c88e6c817008f3a812ed889b4a4da8e0bd103f86e7335422aa1a006ca79302182a030aa100818258205d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c15840c5996650c438c4493b2c8a94229621bb9b151b8d61d75fb868c305e917031e9a1654f35023f7dbf5d1839ab9d57b153c7f79c2666af51ecf363780397956e00af6',
+            },
+        },
+    ];
+
+    return {
+        testPayloads,
+        expectedResponses,
+        specName: '/signMainnetTx',
+    };
+};
+
 const signTestnet = () => {
     const inputs = [
-        SAMPLE_INPUT,
+        SAMPLE_INPUTS['byron_input'],
     ];
     const outputs = [
         SAMPLE_OUTPUTS['testnet_output'],
-        SAMPLE_OUTPUTS['change_output'],
+        SAMPLE_OUTPUTS['shelley_testnet_output'],
+        SAMPLE_OUTPUTS['byron_change_output'],
     ];
 
     const testPayloads: CardanoSignTransaction[] = [
@@ -117,14 +334,15 @@ const signTestnet = () => {
             fee: FEE,
             ttl: TTL,
             protocolMagic: PROTOCOL_MAGICS['testnet'],
+            networkId: NETWORK_IDS['testnet'],
         },
     ];
 
     const expectedResponses = [
         {
             payload: {
-                hash: '5dd03fb44cb88061b2a1c246981bb31adfe4f57be69b58badb5ae8f448450932',
-                serializedTx: '83a400818258201af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc00018282582f82d818582583581c586b90cf80c021db288ce1c18ecfd3610acf64f8748768b0eb7335b1a10242182a001aae3129311a002dd2e882582f82d818582583581c98c3a558f39d1d993cc8770e8825c70a6d0f5a9eb243501c4526c29da10242182a001aa8566c011a000f424002182a030aa1028184582089053545a6c254b0d9b1464e48d2b5fcf91d4e25c128afb1fcfc61d0843338ea5840fc30afdd0d4a6d8581e0f6abe895994d208fd382f2b23ff1553d711477a4fedbd1f68a76e7465c4816d5477f4287f7360acf71fca3b3d5902e4448e48c447106582026308151516f3b0e02bb1638142747863c520273ce9bd3e5cd91e1d46fe2a63545a10242182af6',
+                hash: '47cf79f20c6c62edb4162b3b232a57afc1bd0b57c7fd8389555276408a004776',
+                serializedTx: '83a400818258201af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc00018382582f82d818582583581cc817d85b524e3d073795819a25cdbb84cff6aa2bbb3a081980d248cba10242182a001a0fb6fc611a002dd2e882581d60cb03849e268f989b5a843107bad7fa2908246986a8f3d643f8c184800182582f82d818582583581c98c3a558f39d1d993cc8770e8825c70a6d0f5a9eb243501c4526c29da10242182a001aa8566c011a000f424002182a030aa1028184582089053545a6c254b0d9b1464e48d2b5fcf91d4e25c128afb1fcfc61d0843338ea5840cc11adf81cb3c3b75a438325f8577666f5cbb4d5d6b73fa6dbbcf5ab36897df34eecacdb54c3bc3ce7fc594ebb2c7aa4db4700f4290facad9b611a035af8710a582026308151516f3b0e02bb1638142747863c520273ce9bd3e5cd91e1d46fe2a63545a10242182af6',
             },
         },
     ];
@@ -140,6 +358,10 @@ export const cardanoSignTransaction = () => {
     const availableSubtests = {
         signMainnetNoChange,
         signMainnetChange,
+        signMainnetBaseAddress,
+        signMainnetBaseHashAddress,
+        signMainnetPointerAddress,
+        signMainnetEnterpriseAddress,
         signTestnet,
     };
     return {

--- a/src/js/core/methods/CardanoSignTransaction.js
+++ b/src/js/core/methods/CardanoSignTransaction.js
@@ -4,6 +4,7 @@ import AbstractMethod from './AbstractMethod';
 import { validateParams, getFirmwareRange } from './helpers/paramsValidator';
 import { getMiscNetwork } from '../../data/CoinInfo';
 import { validatePath } from '../../utils/pathUtils';
+import { addressParametersToProto, validateAddressParameters } from './helpers/cardanoAddressParameters';
 
 import type { CardanoTxInput, CardanoTxOutput } from '../../types/trezor/protobuf';
 import type { CardanoSignedTx as CardanoSignedTxResponse } from '../../types/networks/cardano';
@@ -15,6 +16,7 @@ type Params = {
     fee: string;
     ttl: string;
     protocolMagic: number;
+    networkId: number;
 }
 
 export default class CardanoSignTransaction extends AbstractMethod {
@@ -34,6 +36,7 @@ export default class CardanoSignTransaction extends AbstractMethod {
             { name: 'fee', type: 'string', obligatory: true },
             { name: 'ttl', type: 'string', obligatory: true },
             { name: 'protocolMagic', type: 'number', obligatory: true },
+            { name: 'networkId', type: 'number', obligatory: true },
         ]);
 
         const inputs: Array<CardanoTxInput> = payload.inputs.map(input => {
@@ -56,9 +59,10 @@ export default class CardanoSignTransaction extends AbstractMethod {
                 { name: 'amount', type: 'amount', obligatory: true },
             ]);
 
-            if (output.path) {
+            if (output.addressParameters) {
+                validateAddressParameters(output.addressParameters);
                 return {
-                    address_n: validatePath(output.path, 5),
+                    address_parameters: addressParametersToProto(output.addressParameters),
                     amount: output.amount,
                 };
             } else {
@@ -75,6 +79,7 @@ export default class CardanoSignTransaction extends AbstractMethod {
             fee: payload.fee,
             ttl: payload.ttl,
             protocolMagic: payload.protocolMagic,
+            networkId: payload.networkId,
         };
     }
 
@@ -85,6 +90,7 @@ export default class CardanoSignTransaction extends AbstractMethod {
             this.params.fee,
             this.params.ttl,
             this.params.protocolMagic,
+            this.params.networkId,
         );
 
         return {

--- a/src/js/core/methods/helpers/cardanoAddressParameters.js
+++ b/src/js/core/methods/helpers/cardanoAddressParameters.js
@@ -1,0 +1,48 @@
+/* @flow */
+import { validateParams } from '../helpers/paramsValidator';
+import { validatePath } from '../../../utils/pathUtils';
+
+import type { CardanoAddressParameters as CardanoAddressParametersProto } from '../../../types/trezor/protobuf';
+import type { CardanoAddressParameters } from '../../../types/networks/cardano';
+
+export const validateAddressParameters = (addressParameters: CardanoAddressParameters) => {
+    validateParams(addressParameters, [
+        { name: 'addressType', type: 'number', obligatory: true },
+        { name: 'path', type: 'string', obligatory: true },
+        { name: 'stakingPath', type: 'string' },
+        { name: 'stakingKeyHash', type: 'string' },
+    ]);
+    if (addressParameters.certificatePointer) {
+        validateParams(addressParameters.certificatePointer, [
+            { name: 'blockIndex', type: 'number', obligatory: true },
+            { name: 'txIndex', type: 'number', obligatory: true },
+            { name: 'certificateIndex', type: 'number', obligatory: true },
+        ]);
+    }
+};
+
+export const addressParametersToProto = (addressParameters: CardanoAddressParameters): CardanoAddressParametersProto => {
+    const path = validatePath(addressParameters.path, 3);
+
+    let stakingPath = [];
+    if (addressParameters.stakingPath) {
+        stakingPath = validatePath(addressParameters.stakingPath, 3);
+    }
+
+    let certificatePointer;
+    if (addressParameters.certificatePointer) {
+        certificatePointer = {
+            block_index: addressParameters.certificatePointer.blockIndex,
+            tx_index: addressParameters.certificatePointer.txIndex,
+            certificate_index: addressParameters.certificatePointer.certificateIndex,
+        };
+    }
+
+    return {
+        address_type: addressParameters.addressType,
+        address_n: path,
+        address_n_staking: stakingPath,
+        staking_key_hash: addressParameters.stakingKeyHash,
+        certificate_pointer: certificatePointer,
+    };
+};

--- a/src/js/core/methods/helpers/cardanoAddressParameters.js
+++ b/src/js/core/methods/helpers/cardanoAddressParameters.js
@@ -46,3 +46,22 @@ export const addressParametersToProto = (addressParameters: CardanoAddressParame
         certificate_pointer: certificatePointer,
     };
 };
+
+export const addressParametersFromProto = (addressParameters: CardanoAddressParametersProto): CardanoAddressParameters => {
+    let certificatePointer;
+    if (addressParameters.certificate_pointer) {
+        certificatePointer = {
+            blockIndex: addressParameters.certificate_pointer.block_index,
+            txIndex: addressParameters.certificate_pointer.tx_index,
+            certificateIndex: addressParameters.certificate_pointer.certificate_index,
+        };
+    }
+
+    return {
+        addressType: addressParameters.address_type,
+        path: addressParameters.address_n,
+        stakingPath: addressParameters.address_n_staking,
+        stakingKeyHash: addressParameters.staking_key_hash,
+        certificatePointer: certificatePointer,
+    };
+};

--- a/src/js/device/DeviceCommands.js
+++ b/src/js/device/DeviceCommands.js
@@ -400,10 +400,11 @@ export default class DeviceCommands {
         return response.message;
     }
 
-    async cardanoGetAddress(address_n: Array<number>, protocolMagic: number, showOnTrezor: boolean): Promise<trezor.CardanoAddress> {
+    async cardanoGetAddress(addressParameters: trezor.CardanoAddressParameters, protocolMagic: number, networkId: number, showOnTrezor: boolean): Promise<trezor.CardanoAddress> {
         const response: MessageResponse<trezor.CardanoAddress> = await this.typedCall('CardanoGetAddress', 'CardanoAddress', {
-            address_n,
+            address_parameters: addressParameters,
             protocol_magic: protocolMagic,
+            network_id: networkId,
             show_display: !!showOnTrezor,
         });
         return response.message;

--- a/src/js/device/DeviceCommands.js
+++ b/src/js/device/DeviceCommands.js
@@ -415,7 +415,8 @@ export default class DeviceCommands {
         outputs: Array<trezor.CardanoTxOutput>,
         fee: string,
         ttl: string,
-        protocolMagic: number
+        protocolMagic: number,
+        networkId: number
     ): Promise<trezor.CardanoSignedTx> {
         const response: MessageResponse<trezor.CardanoSignedTx> = await this.typedCall('CardanoSignTx', 'CardanoSignedTx', {
             inputs,
@@ -423,6 +424,7 @@ export default class DeviceCommands {
             fee,
             ttl,
             protocol_magic: protocolMagic,
+            network_id: networkId,
         });
         return response.message;
     }

--- a/src/js/types/__tests__/cardano.js
+++ b/src/js/types/__tests__/cardano.js
@@ -205,10 +205,25 @@ export const cardanoSignTransaction = async () => {
                 address: 'Ae2..',
                 amount: '3003112',
             },
+            {
+                addressParameters: {
+                    addressType: 0,
+                    path: 'm/44',
+                    stakingPath: 'm/44',
+                    stakingKeyHash: 'aaff00..',
+                    certificatePointer: {
+                        blockIndex: 0,
+                        txIndex: 0,
+                        certificateIndex: 0,
+                    },
+                },
+                amount: '3003112',
+            },
         ],
         fee: '42',
         ttl: '10',
         protocolMagic: 0,
+        networkId: 0,
     });
 
     if (sign.success) {

--- a/src/js/types/__tests__/cardano.js
+++ b/src/js/types/__tests__/cardano.js
@@ -3,25 +3,80 @@ import TrezorConnect from '../../index';
 
 export const cardanoGetAddress = async () => {
     // regular
-    const singleAddress = await TrezorConnect.cardanoGetAddress({ path: 'm/44', protocolMagic: 0 });
+    const singleAddress = await TrezorConnect.cardanoGetAddress({
+        addressParameters: {
+            addressType: 0,
+            path: 'm/44',
+            stakingPath: 'm/44',
+            stakingKeyHash: 'aaff00..',
+            certificatePointer: {
+                blockIndex: 0,
+                txIndex: 1,
+                certificateIndex: 2,
+            },
+        },
+        protocolMagic: 0,
+        networkId: 0,
+    });
     (singleAddress.success: boolean);
     if (singleAddress.success) {
         const { payload } = singleAddress;
         (payload.address: string);
-        (payload.path: number[]);
         (payload.protocolMagic: number);
+        (payload.networkId: number);
         (payload.serializedPath: string);
+        (payload.serializedStakingPath: string);
+        const { addressParameters } = payload;
+        (addressParameters.addressType: number);
+        (addressParameters.path: string | number[]);
+        (addressParameters.stakingPath: ?string | ?number[]);
+        (addressParameters.stakingKeyHash: ?string);
+        const { certificatePointer } = addressParameters;
+        if (certificatePointer) {
+            (certificatePointer.blockIndex: ?number);
+            (certificatePointer.txIndex: ?number);
+            (certificatePointer.certificateIndex: ?number);
+        }
     }
 
     // bundle
-    const bundleAddress = await TrezorConnect.cardanoGetAddress({ bundle: [{ path: 'm/44', protocolMagic: 0 }] });
+    const bundleAddress = await TrezorConnect.cardanoGetAddress({
+        bundle: [
+            {
+                addressParameters: {
+                    addressType: 0,
+                    path: 'm/44',
+                    stakingPath: 'm/44',
+                    stakingKeyHash: 'aaff00..',
+                    certificatePointer: {
+                        blockIndex: 0,
+                        txIndex: 1,
+                        certificateIndex: 2,
+                    },
+                },
+                protocolMagic: 0,
+                networkId: 0,
+            },
+        ],
+    });
     (bundleAddress.success: boolean);
     if (bundleAddress.success) {
         bundleAddress.payload.forEach(item => {
             (item.address: string);
-            (item.path: number[]);
             (item.protocolMagic: number);
+            (item.networkId: number);
             (item.serializedPath: string);
+            (item.serializedStakingPath: string);
+            const { addressParameters } = item;
+            (addressParameters.addressType: number);
+            (addressParameters.path: string | number[]);
+            (addressParameters.stakingPath: ?string | number[]);
+            const { certificatePointer } = addressParameters;
+            if (certificatePointer) {
+                (certificatePointer.blockIndex: ?number);
+                (certificatePointer.txIndex: ?number);
+                (certificatePointer.certificateIndex: ?number);
+            }
         });
     } else {
         (bundleAddress.payload.error: string);
@@ -38,14 +93,31 @@ export const cardanoGetAddress = async () => {
         allowSeedlessDevice: false,
         keepSession: false,
         skipFinalReload: false,
-        path: 'm/44',
+        addressParameters: {
+            addressType: 0,
+            path: 'm/44',
+            stakingPath: 'm/44',
+            stakingKeyHash: 'aaff00..',
+            certificatePointer: {
+                blockIndex: 0,
+                txIndex: 1,
+                certificateIndex: 2,
+            },
+        },
         address: 'a',
         protocolMagic: 0,
+        networkId: 0,
         showOnTrezor: true,
     });
 
     // $ExpectError: payload is Address
-    const e1 = await TrezorConnect.cardanoGetAddress({ path: 'm/44' });
+    const e1 = await TrezorConnect.cardanoGetAddress({
+        addressParameters: {
+            addressType: 0,
+            path: 'm/44',
+            stakingPath: 'm/44',
+        },
+    });
     if (e1.success) {
         e1.payload.forEach(item => {
             (item.address: string);
@@ -53,7 +125,19 @@ export const cardanoGetAddress = async () => {
     }
 
     // $ExpectError: payload is Address[]
-    const e2 = await TrezorConnect.cardanoGetAddress({ bundle: [{ path: 'm/44' }] });
+    const e2 = await TrezorConnect.cardanoGetAddress({
+        bundle: [
+            {
+                addressParameters: {
+                    addressType: 0,
+                    path: 'm/44',
+                    stakingPath: 'm/44',
+                },
+                protocolMagic: 0,
+                networkId: 0,
+            },
+        ],
+    });
     if (e2.success) e2.payload.address;
 
     // with invalid params
@@ -62,7 +146,7 @@ export const cardanoGetAddress = async () => {
     // $ExpectError
     TrezorConnect.cardanoGetAddress({ coin: 'btc' });
     // $ExpectError
-    TrezorConnect.cardanoGetAddress({ path: 1 });
+    TrezorConnect.cardanoGetAddress({ addressParameters: { path: 1 } });
     // $ExpectError
     TrezorConnect.cardanoGetAddress({ bundle: 1 });
 };

--- a/src/js/types/networks/cardano.js
+++ b/src/js/types/networks/cardano.js
@@ -3,7 +3,7 @@
 // Cardano method parameters types
 import type { HDPubNode } from '../trezor/protobuf';
 
-// GetAddress
+// GetPublicKey
 
 export type CardanoGetPublicKey = {
     path: string | number[];
@@ -19,17 +19,43 @@ export type CardanoPublicKey = {
 
 // GetAddress
 
-export type CardanoGetAddress = {
+export const CARDANO_ADDRESS_TYPE = Object.freeze({
+    Base: 0,
+    Pointer: 4,
+    Enterprise: 6,
+    Byron: 8,
+    Reward: 14,
+});
+export type CardanoAddressType = $Values<typeof CARDANO_ADDRESS_TYPE>;
+
+export type CardanoCertificatePointer = {
+    blockIndex: number;
+    txIndex: number;
+    certificateIndex: number;
+}
+
+export type CardanoAddressParameters = {
+    addressType: CardanoAddressType;
     path: string | number[];
-    address?: string;
+    stakingPath?: string | number[];
+    stakingKeyHash?: string;
+    certificatePointer?: CardanoCertificatePointer;
+};
+
+export type CardanoGetAddress = {
+    addressParameters: CardanoAddressParameters;
     protocolMagic: number;
+    networkId: number;
+    address?: string;
     showOnTrezor?: boolean;
 }
 
 export type CardanoAddress = {
-    path: number[];
-    serializedPath: string;
+    addressParameters: CardanoAddressParameters;
     protocolMagic: number;
+    networkId: number;
+    serializedPath: string;
+    serializedStakingPath: string;
     address: string;
 }
 

--- a/src/js/types/networks/cardano.js
+++ b/src/js/types/networks/cardano.js
@@ -67,7 +67,7 @@ export type CardanoInput = {
     prev_index: number;
 }
 export type CardanoOutput = {
-    path: string | number[];
+    addressParameters: CardanoAddressParameters;
     amount: string;
 } | {
     address: string;
@@ -80,6 +80,7 @@ export type CardanoSignTransaction = {
     fee: string;
     ttl: string;
     protocolMagic: number;
+    networkId: number;
 }
 
 export type CardanoSignedTx = {

--- a/src/js/types/trezor/protobuf.js
+++ b/src/js/types/trezor/protobuf.js
@@ -601,7 +601,7 @@ export type CardanoTxInput = {
 };
 export type CardanoTxOutput = {
     address?: string;
-    address_n?: Array<number>;
+    address_parameters?: CardanoAddressParameters;
     amount: string;
 };
 

--- a/src/js/types/trezor/protobuf.js
+++ b/src/js/types/trezor/protobuf.js
@@ -566,6 +566,20 @@ export type TezosSignedTx = {
 };
 
 // Cardano types
+export type CardanoCertificatePointerType = {
+    block_index: number;
+    tx_index: number;
+    certificate_index: number;
+}
+
+export type CardanoAddressParameters = {
+    address_type: number;
+    address_n: number[];
+    address_n_staking: number[];
+    staking_key_hash?: string;
+    certificate_pointer?: CardanoCertificatePointerType;
+};
+
 export type CardanoAddress = {
     address: string;
     address_n?: Array<number>;

--- a/src/ts/types/__tests__/cardano.ts
+++ b/src/ts/types/__tests__/cardano.ts
@@ -2,13 +2,39 @@ import TrezorConnect from '../index';
 
 export const cardanoGetAddress = async () => {
     // regular
-    const singleAddress = await TrezorConnect.cardanoGetAddress({ path: 'm/44', protocolMagic: 0 });
+    const singleAddress = await TrezorConnect.cardanoGetAddress({
+        addressParameters: {
+            addressType: 0,
+            path: 'm/44',
+            stakingPath: 'm/44',
+            stakingKeyHash: 'aaff00..',
+            certificatePointer: {
+                blockIndex: 0,
+                txIndex: 1,
+                certificateIndex: 2,
+            },
+        },
+        protocolMagic: 0,
+        networkId: 0,
+    });
     if (singleAddress.success) {
         const { payload } = singleAddress;
         payload.address;
-        payload.path;
         payload.protocolMagic;
+        payload.networkId;
         payload.serializedPath;
+        payload.serializedStakingPath;
+        const { addressParameters } = payload;
+        addressParameters.addressType;
+        addressParameters.path;
+        addressParameters.stakingPath;
+        addressParameters.stakingKeyHash;
+        const { certificatePointer } = addressParameters;
+        if (certificatePointer) {
+            certificatePointer.blockIndex;
+            certificatePointer.txIndex;
+            certificatePointer.certificateIndex;
+        }
         // @ts-ignore
         payload.forEach(item => {
             item.address;
@@ -16,13 +42,43 @@ export const cardanoGetAddress = async () => {
     }
 
     // bundle
-    const bundleAddress = await TrezorConnect.cardanoGetAddress({ bundle: [{ path: 'm/44', protocolMagic: 0 }] });
+    const bundleAddress = await TrezorConnect.cardanoGetAddress({
+        bundle: [
+            {
+                addressParameters: {
+                    addressType: 0,
+                    path: 'm/44',
+                    stakingPath: 'm/44',
+                    stakingKeyHash: 'aaff00..',
+                    certificatePointer: {
+                        blockIndex: 0,
+                        txIndex: 1,
+                        certificateIndex: 2,
+                    },
+                },
+                protocolMagic: 0,
+                networkId: 0,
+            },
+        ],
+    });
     if (bundleAddress.success) {
         bundleAddress.payload.forEach(item => {
             item.address;
-            item.path;
             item.protocolMagic;
+            item.networkId;
             item.serializedPath;
+            item.serializedStakingPath;
+            const { addressParameters } = item;
+            addressParameters.addressType;
+            addressParameters.path;
+            addressParameters.stakingPath;
+            addressParameters.stakingKeyHash;
+            const { certificatePointer } = addressParameters;
+            if (certificatePointer) {
+                certificatePointer.blockIndex;
+                certificatePointer.txIndex;
+                certificatePointer.certificateIndex;
+            }
         });
         // @ts-ignore
         bundleAddress.payload.address;
@@ -41,9 +97,20 @@ export const cardanoGetAddress = async () => {
         allowSeedlessDevice: false,
         keepSession: false,
         skipFinalReload: false,
-        path: 'm/44',
+        addressParameters: {
+            addressType: 0,
+            path: 'm/44',
+            stakingPath: 'm/44',
+            stakingKeyHash: 'aaff00..',
+            certificatePointer: {
+                blockIndex: 0,
+                txIndex: 1,
+                certificateIndex: 2,
+            },
+        },
         address: 'a',
         protocolMagic: 0,
+        networkId: 0,
         showOnTrezor: true,
     });
 
@@ -53,7 +120,7 @@ export const cardanoGetAddress = async () => {
     // @ts-ignore
     TrezorConnect.cardanoGetAddress({ coin: 'btc' });
     // @ts-ignore
-    TrezorConnect.cardanoGetAddress({ path: 1 });
+    TrezorConnect.cardanoGetAddress({ addressParameters: { path: 1 } });
     // @ts-ignore
     TrezorConnect.cardanoGetAddress({ bundle: 1 });
 };

--- a/src/ts/types/__tests__/cardano.ts
+++ b/src/ts/types/__tests__/cardano.ts
@@ -170,10 +170,25 @@ export const cardanoSignTransaction = async () => {
                 address: 'Ae2..',
                 amount: '3003112',
             },
+            {
+                addressParameters: {
+                    addressType: 0,
+                    path: 'm/44',
+                    stakingPath: 'm/44',
+                    stakingKeyHash: 'aaff00..',
+                    certificatePointer: {
+                        blockIndex: 0,
+                        txIndex: 0,
+                        certificateIndex: 0,
+                    },
+                },
+                amount: '3003112',
+            },
         ],
         fee: '42',
         ttl: '10',
         protocolMagic: 0,
+        networkId: 0,
     });
 
     if (sign.success) {

--- a/src/ts/types/networks/cardano.d.ts
+++ b/src/ts/types/networks/cardano.d.ts
@@ -17,17 +17,42 @@ export interface CardanoPublicKey {
 
 // GetAddress
 
-export interface CardanoGetAddress {
+export enum CardanoAddressType {
+    Base = 0,
+    Pointer = 4,
+    Enterprise = 6,
+    Byron = 8,
+    Reward = 14,
+}
+
+export interface CardanoCertificatePointer {
+    blockIndex: number;
+    txIndex: number;
+    certificateIndex: number;
+}
+
+export interface CardanoAddressParameters {
+    addressType: CardanoAddressType;
     path: string | number[];
-    address?: string;
+    stakingPath?: string | number[];
+    stakingKeyHash?: string;
+    certificatePointer?: CardanoCertificatePointer;
+};
+
+export interface CardanoGetAddress {
+    addressParameters: CardanoAddressParameters;
     protocolMagic: number;
+    networkId: number;
+    address?: string;
     showOnTrezor?: boolean;
 }
 
 export interface CardanoAddress {
-    path: number[];
-    serializedPath: string;
+    addressParameters: CardanoAddressParameters;
     protocolMagic: number;
+    networkId: number;
+    serializedPath: string;
+    serializedStakingPath: string;
     address: string;
 }
 

--- a/src/ts/types/networks/cardano.d.ts
+++ b/src/ts/types/networks/cardano.d.ts
@@ -65,7 +65,7 @@ export interface CardanoInput {
 }
 export type CardanoOutput =
     | {
-          path: string | number[];
+          addressParameters: CardanoAddressParameters;
           amount: string;
       }
     | {
@@ -79,6 +79,7 @@ export interface CardanoSignTransaction {
     fee: string;
     ttl: string;
     protocolMagic: number;
+    networkId: number;
 }
 
 export interface CardanoSignedTx {

--- a/tests/__fixtures__/cardanoGetAddress.js
+++ b/tests/__fixtures__/cardanoGetAddress.js
@@ -1,80 +1,269 @@
+import { CARDANO_ADDRESS_TYPE } from '../../src/js/types/networks/cardano';
+
 const PROTOCOL_MAGICS = {
     mainnet: 764824073,
     testnet: 42,
 };
 
+const NETWORK_IDS = {
+    mainnet: 1,
+    testnet: 0,
+};
+
 export default {
     method: 'cardanoGetAddress',
     setup: {
-        mnemonic: 'mnemonic_12',
+        mnemonic: 'mnemonic_all',
     },
     tests: [
         {
             description: "Mainnet - m/44'/1815'/0'/0/0",
             params: {
-                path: "m/44'/1815'/0'/0/0",
+                addressParameters: {
+                    addressType: CARDANO_ADDRESS_TYPE.Byron,
+                    path: "m/44'/1815'/0'/0/0",
+                },
                 protocolMagic: PROTOCOL_MAGICS['mainnet'],
+                networkId: NETWORK_IDS['mainnet'],
             },
             result: {
-                address: 'Ae2tdPwUPEZLCq3sFv4wVYxwqjMH2nUzBVt1HFr4v87snYrtYq3d3bq2PUQ',
+                address: 'Ae2tdPwUPEZ5YUb8sM3eS8JqKgrRLzhiu71crfuH2MFtqaYr5ACNRdsswsZ',
             },
         },
         {
-            description: "Mainnet - m/44'/1815'",
+            description: "Byron Mainnet - m/44'/1815'",
             params: {
-                path: "m/44'/1815'",
+                addressParameters: {
+                    addressType: CARDANO_ADDRESS_TYPE.Byron,
+                    path: "m/44'/1815'",
+                },
                 protocolMagic: PROTOCOL_MAGICS['mainnet'],
+                networkId: NETWORK_IDS['mainnet'],
             },
             result: false,
         },
         {
-            description: "Mainnet - m/44'/1815'/0'/0/1",
+            description: "Byron Mainnet - m/44'/1815'/0'/0/1",
             params: {
-                path: "m/44'/1815'/0'/0/1",
+                addressParameters: {
+                    addressType: CARDANO_ADDRESS_TYPE.Byron,
+                    path: "m/44'/1815'/0'/0/1",
+                },
                 protocolMagic: PROTOCOL_MAGICS['mainnet'],
+                networkId: NETWORK_IDS['mainnet'],
             },
             result: {
-                address: 'Ae2tdPwUPEZEY6pVJoyuNNdLp7VbMB7U7qfebeJ7XGunk5Z2eHarkcN1bHK',
+                address: 'Ae2tdPwUPEZJb8r1VZxweSwHDTYtqeYqF39rZmVbrNK62JHd4Wd7Ytsc8eG',
             },
         },
         {
-            description: "Mainnet - m/44'/1815'/0'/0/2",
+            description: "Byron Mainnet- m/44'/1815'/0'/0/2",
             params: {
-                path: "m/44'/1815'/0'/0/2",
+                addressParameters: {
+                    addressType: CARDANO_ADDRESS_TYPE.Byron,
+                    path: "m/44'/1815'/0'/0/2",
+                },
                 protocolMagic: PROTOCOL_MAGICS['mainnet'],
+                networkId: NETWORK_IDS['mainnet'],
             },
             result: {
-                address: 'Ae2tdPwUPEZ3gZD1QeUHvAqadAV59Zid6NP9VCR9BG5LLAja9YtBUgr6ttK',
+                address: 'Ae2tdPwUPEZFm6Y7aPZGKMyMAK16yA5pWWKU9g73ncUQNZsAjzjhszenCsq',
             },
         },
         {
-            description: "Testnet - m/44'/1815'/0'/0/0",
+            description: "Byron Testnet - m/44'/1815'/0'/0/0",
             params: {
-                path: "m/44'/1815'/0'/0/0",
+                addressParameters: {
+                    addressType: CARDANO_ADDRESS_TYPE.Byron,
+                    path: "m/44'/1815'/0'/0/0",
+                },
                 protocolMagic: PROTOCOL_MAGICS['testnet'],
+                networkId: NETWORK_IDS['testnet'],
             },
             result: {
-                address: '2657WMsDfac5vydkak9a7BqGrsLqBzB7K3vT55rucZKYDmVnUCf6hXAFkZSTcUx7r',
+                address: '2657WMsDfac5F3zbgs9BwNWx3dhGAJERkAL93gPa68NJ2i8mbCHm2pLUHWSj8Mfea',
             },
         },
         {
-            description: "Testnet - m/44'/1815'/0'/0/1",
+            description: "Byron Testnet - m/44'/1815'/0'/0/1",
             params: {
-                path: "m/44'/1815'/0'/0/1",
+                addressParameters: {
+                    addressType: CARDANO_ADDRESS_TYPE.Byron,
+                    path: "m/44'/1815'/0'/0/1",
+                },
                 protocolMagic: PROTOCOL_MAGICS['testnet'],
+                networkId: NETWORK_IDS['testnet'],
             },
             result: {
-                address: '2657WMsDfac61ebUDw53WUX49Dcfya8S8G7iYbhN4nP8JSFuh38T1LuFax1bUnhxA',
+                address: '2657WMsDfac6ezKWszxLFqJjSUgpg9NgxKc1koqi24sVpRaPhiwMaExk4useKn5HA',
             },
         },
         {
-            description: "Testnet - m/44'/1815'/0'/0/2",
+            description: "Byron Testnet - m/44'/1815'/0'/0/2",
             params: {
-                path: "m/44'/1815'/0'/0/2",
+                addressParameters: {
+                    addressType: CARDANO_ADDRESS_TYPE.Byron,
+                    path: "m/44'/1815'/0'/0/2",
+                },
                 protocolMagic: PROTOCOL_MAGICS['testnet'],
+                networkId: NETWORK_IDS['testnet'],
             },
             result: {
-                address: '2657WMsDfac5PMpEsxc1md3pgZKUZRZ11MUK8tjkDHBQG9b3TMBsTQc4PmmumVrcn',
+                address: '2657WMsDfac7hr1ioJGr6g7r6JRx4r1My8Rj91tcPTeVjJDpfBYKURrPG2zVLx2Sq',
+            },
+        },
+        {
+            description: "Base Mainnet - m/1852'/1815'/4'/0/0",
+            params: {
+                addressParameters: {
+                    addressType: CARDANO_ADDRESS_TYPE.Base,
+                    path: "m/1852'/1815'/4'/0/0",
+                    stakingPath: "m/1852'/1815'/4'/2/0",
+                },
+                protocolMagic: PROTOCOL_MAGICS['mainnet'],
+                networkId: NETWORK_IDS['mainnet'],
+            },
+            result: {
+                address: 'addr1q8v42wjda8r6mpfj40d36znlgfdcqp7jtj03ah8skh6u8wnrqua2vw243tmjfjt0h5wsru6appuz8c0pfd75ur7myyeqsx9990',
+            },
+        },
+        {
+            description: "Base Testnet - m/1852'/1815'/4'/0/0",
+            params: {
+                addressParameters: {
+                    addressType: CARDANO_ADDRESS_TYPE.Base,
+                    path: "m/1852'/1815'/4'/0/0",
+                    stakingPath: "m/1852'/1815'/4'/2/0",
+                },
+                protocolMagic: PROTOCOL_MAGICS['testnet'],
+                networkId: NETWORK_IDS['testnet'],
+            },
+            result: {
+                address: 'addr_test1qrv42wjda8r6mpfj40d36znlgfdcqp7jtj03ah8skh6u8wnrqua2vw243tmjfjt0h5wsru6appuz8c0pfd75ur7myyeqnsc9fs',
+            },
+        },
+        {
+            description: "Base Hash Mainnet - m/1852'/1815'/4'/0/0",
+            params: {
+                addressParameters: {
+                    addressType: CARDANO_ADDRESS_TYPE.Base,
+                    path: "m/1852'/1815'/4'/0/0",
+                    stakingKeyHash: '1bc428e4720702ebd5dab4fb175324c192dc9bb76cc5da956e3c8dff',
+                },
+                protocolMagic: PROTOCOL_MAGICS['mainnet'],
+                networkId: NETWORK_IDS['mainnet'],
+            },
+            result: {
+                address: 'addr1q8v42wjda8r6mpfj40d36znlgfdcqp7jtj03ah8skh6u8wsmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlsydc62k',
+            },
+        },
+        {
+            description: "Base Hash Testnet - m/1852'/1815'/4'/0/0",
+            params: {
+                addressParameters: {
+                    addressType: CARDANO_ADDRESS_TYPE.Base,
+                    path: "m/1852'/1815'/4'/0/0",
+                    stakingKeyHash: '1bc428e4720702ebd5dab4fb175324c192dc9bb76cc5da956e3c8dff',
+                },
+                protocolMagic: PROTOCOL_MAGICS['testnet'],
+                networkId: NETWORK_IDS['testnet'],
+            },
+            result: {
+                address: 'addr_test1qrv42wjda8r6mpfj40d36znlgfdcqp7jtj03ah8skh6u8wsmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hls8m96xf',
+            },
+        },
+        {
+            description: "Enterprise Mainnet - m/1852'/1815'/0'/0/0",
+            params: {
+                addressParameters: {
+                    addressType: CARDANO_ADDRESS_TYPE.Enterprise,
+                    path: "m/1852'/1815'/0'/0/0",
+                },
+                protocolMagic: PROTOCOL_MAGICS['mainnet'],
+                networkId: NETWORK_IDS['mainnet'],
+            },
+            result: {
+                address: 'addr1vxq0nckg3ekgzuqg7w5p9mvgnd9ym28qh5grlph8xd2z92su77c6m',
+            },
+        },
+        {
+            description: "Enterprise Testnet - m/1852'/1815'/0'/0/0",
+            params: {
+                addressParameters: {
+                    addressType: CARDANO_ADDRESS_TYPE.Enterprise,
+                    path: "m/1852'/1815'/0'/0/0",
+                },
+                protocolMagic: PROTOCOL_MAGICS['testnet'],
+                networkId: NETWORK_IDS['testnet'],
+            },
+            result: {
+                address: 'addr_test1vzq0nckg3ekgzuqg7w5p9mvgnd9ym28qh5grlph8xd2z92s8k2y47',
+            },
+        },
+        {
+            description: "Pointer Mainnet - m/1852'/1815'/0'/0/0",
+            params: {
+                addressParameters: {
+                    addressType: CARDANO_ADDRESS_TYPE.Pointer,
+                    path: "m/1852'/1815'/0'/0/0",
+                    certificatePointer: {
+                        blockIndex: 1,
+                        txIndex: 2,
+                        certificateIndex: 3,
+                    },
+                },
+                protocolMagic: PROTOCOL_MAGICS['mainnet'],
+                networkId: NETWORK_IDS['mainnet'],
+            },
+            result: {
+                address: 'addr1gxq0nckg3ekgzuqg7w5p9mvgnd9ym28qh5grlph8xd2z92spqgpsl97q83',
+            },
+        },
+        {
+            description: "Pointer Testnet - m/1852'/1815'/0'/0/0",
+            params: {
+                addressParameters: {
+                    addressType: CARDANO_ADDRESS_TYPE.Pointer,
+                    path: "m/1852'/1815'/0'/0/0",
+                    certificatePointer: {
+                        blockIndex: 24157,
+                        txIndex: 177,
+                        certificateIndex: 42,
+                    },
+                },
+                protocolMagic: PROTOCOL_MAGICS['testnet'],
+                networkId: NETWORK_IDS['testnet'],
+            },
+            result: {
+                address: 'addr_test1gzq0nckg3ekgzuqg7w5p9mvgnd9ym28qh5grlph8xd2z925ph3wczvf2ag2x9t',
+            },
+        },
+        {
+            description: "Reward Mainnet - m/1852'/1815'/0'/2/0",
+            params: {
+                addressParameters: {
+                    addressType: CARDANO_ADDRESS_TYPE.Reward,
+                    path: "m/1852'/1815'/0'/2/0",
+                },
+                protocolMagic: PROTOCOL_MAGICS['mainnet'],
+                networkId: NETWORK_IDS['mainnet'],
+            },
+            result: {
+                address: 'stake1uyfz49rtntfa9h0s98f6s28sg69weemgjhc4e8hm66d5yacalmqha',
+            },
+        },
+        {
+            description: "Reward Testnet - m/1852'/1815'/0'/2/0",
+            params: {
+                addressParameters: {
+                    addressType: CARDANO_ADDRESS_TYPE.Reward,
+                    path: "m/1852'/1815'/0'/2/0",
+                },
+                protocolMagic: PROTOCOL_MAGICS['testnet'],
+                networkId: NETWORK_IDS['testnet'],
+            },
+            result: {
+                address: 'stake_test1uqfz49rtntfa9h0s98f6s28sg69weemgjhc4e8hm66d5yac643znq',
             },
         },
     ],

--- a/tests/__fixtures__/cardanoSignTransaction.js
+++ b/tests/__fixtures__/cardanoSignTransaction.js
@@ -1,20 +1,82 @@
+import { CARDANO_ADDRESS_TYPE } from '../../src/js/types/networks/cardano';
+
 // vectors from https://github.com/trezor/trezor-firmware/tree/master/python/trezorlib/tests/device_tests/test_msg_cardano_sign_transaction.py
 
-const SAMPLE_INPUT = {
-    path: "m/44'/1815'/0'/0/1",
-    prev_hash: '1af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc',
-    prev_index: 0,
+const SAMPLE_INPUTS = {
+    byron_input: {
+        path: "m/44'/1815'/0'/0/1",
+        prev_hash: '1af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc',
+        prev_index: 0,
+    },
+    shelley_input: {
+        path: "m/1852'/1815'/0'/0/0",
+        prev_hash: '3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7',
+        prev_index: 0,
+    },
 };
 
 const SAMPLE_OUTPUTS = {
-    simple_output: {
+    simple_byron_output: {
         address: 'Ae2tdPwUPEZCanmBz5g2GEwFqKTKpNJcGYPKfDxoNeKZ8bRHr8366kseiK2',
         amount: '3003112',
     },
-    change_output: {path: "m/44'/1815'/0'/0/1", amount: '1000000'},
+    byron_change_output: {
+        addressParameters: {
+            addressType: CARDANO_ADDRESS_TYPE.Byron,
+            path: "m/44'/1815'/0'/0/1",
+        },
+        amount: '1000000',
+    },
+    simple_shelley_output: {
+        address: 'addr1q84sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlsd5tq5r',
+        amount: '1',
+    },
+    base_address_with_script_output: {
+        address: 'addr1z90z7zqwhya6mpk5q929ur897g3pp9kkgalpreny8y304r2dcrtx0sf3dluyu4erzr3xtmdnzvcyfzekkuteu2xagx0qeva0pr',
+        amount: '7120787',
+    },
+    base_address_change_output: {
+        addressParameters: {
+            addressType: CARDANO_ADDRESS_TYPE.Base,
+            path: "m/1852'/1815'/0'/0/0",
+            stakingPath: "m/1852'/1815'/0'/2/0",
+        },
+        amount: '7120787',
+    },
+    staking_key_hash_output: {
+        addressParameters: {
+            addressType: CARDANO_ADDRESS_TYPE.Base,
+            path: "m/1852'/1815'/0'/0/0",
+            stakingKeyHash: '32c728d3861e164cab28cb8f006448139c8f1740ffb8e7aa9e5232dc',
+        },
+        amount: '7120787',
+    },
+    pointer_address_output: {
+        addressParameters: {
+            addressType: CARDANO_ADDRESS_TYPE.Pointer,
+            path: "m/1852'/1815'/0'/0/0",
+            certificatePointer: {
+                blockIndex: 1,
+                txIndex: 2,
+                certificateIndex: 3,
+            },
+        },
+        amount: '7120787',
+    },
+    enterprise_address_output: {
+        addressParameters: {
+            addressType: CARDANO_ADDRESS_TYPE.Enterprise,
+            path: "m/1852'/1815'/0'/0/0",
+        },
+        amount: '7120787',
+    },
     testnet_output: {
-        address: '2657WMsDfac5vydkak9a7BqGrsLqBzB7K3vT55rucZKYDmVnUCf6hXAFkZSTcUx7r',
+        address: '2657WMsDfac7BteXkJq5Jzdog4h47fPbkwUM49isuWbYAr2cFRHa3rURP236h9PBe',
         amount: '3003112',
+    },
+    shelley_testnet_output: {
+        address: 'addr_test1vr9s8py7y68e3x66sscs0wkhlg5ssfrfs65084jrlrqcfqqtmut0e',
+        amount: '1',
     },
 };
 
@@ -26,6 +88,11 @@ const PROTOCOL_MAGICS = {
     testnet: 42,
 };
 
+const NETWORK_IDS = {
+    mainnet: 1,
+    testnet: 0,
+};
+
 export default {
     method: 'cardanoSignTransaction',
     setup: {
@@ -35,11 +102,12 @@ export default {
         {
             description: 'signMainnetNoChange',
             params: {
-                inputs: [SAMPLE_INPUT],
-                outputs: [SAMPLE_OUTPUTS['simple_output']],
+                inputs: [SAMPLE_INPUTS['byron_input']],
+                outputs: [SAMPLE_OUTPUTS['simple_byron_output']],
                 fee: FEE,
                 ttl: TTL,
                 protocolMagic: PROTOCOL_MAGICS['mainnet'],
+                networkId: NETWORK_IDS['mainnet'],
             },
             result: {
                 hash: '73e09bdebf98a9e0f17f86a2d11e0f14f4f8dae77cdf26ff1678e821f20c8db6',
@@ -50,14 +118,15 @@ export default {
         {
             description: 'signMainnetChange',
             params: {
-                inputs: [SAMPLE_INPUT],
+                inputs: [SAMPLE_INPUTS['byron_input']],
                 outputs: [
-                    SAMPLE_OUTPUTS['simple_output'],
-                    SAMPLE_OUTPUTS['change_output'],
+                    SAMPLE_OUTPUTS['simple_byron_output'],
+                    SAMPLE_OUTPUTS['byron_change_output'],
                 ],
                 fee: FEE,
                 ttl: TTL,
                 protocolMagic: PROTOCOL_MAGICS['mainnet'],
+                networkId: NETWORK_IDS['mainnet'],
             },
             result: {
                 hash: '81b14b7e62972127eb33c0b1198de6430540ad3a98eec621a3194f2baac43a43',
@@ -66,22 +135,99 @@ export default {
         },
 
         {
+            description: 'signMainnetBaseAddress',
+            params: {
+                inputs: [SAMPLE_INPUTS['shelley_input']],
+                outputs: [
+                    SAMPLE_OUTPUTS['simple_shelley_output'],
+                    SAMPLE_OUTPUTS['base_address_change_output'],
+                ],
+                fee: FEE,
+                ttl: TTL,
+                protocolMagic: PROTOCOL_MAGICS['mainnet'],
+                networkId: NETWORK_IDS['mainnet'],
+            },
+            result: {
+                hash: '16fe72bb198be423677577e6326f1f648ec5fc11263b072006382d8125a6edda',
+                serializedTx: '83a400818258203b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b700018282583901eb0baa5e570cffbe2934db29df0b6a3d7c0430ee65d4c3a7ab2fefb91bc428e4720702ebd5dab4fb175324c192dc9bb76cc5da956e3c8dff018258390180f9e2c88e6c817008f3a812ed889b4a4da8e0bd103f86e7335422aa122a946b9ad3d2ddf029d3a828f0468aece76895f15c9efbd69b42771a006ca79302182a030aa100818258205d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c158406a78f07836dcf4a303448d2b16b217265a9226be3984a69a04dba5d04f4dbb2a47b5e1cbb345f474c0b9634a2f37b921ab26e6a65d5dfd015dacb4455fb8430af6',
+            },
+        },
+
+        {
+            description: 'signMainnetBaseHashAddress',
+            params: {
+                inputs: [SAMPLE_INPUTS['shelley_input']],
+                outputs: [
+                    SAMPLE_OUTPUTS['simple_shelley_output'],
+                    SAMPLE_OUTPUTS['staking_key_hash_output'],
+                ],
+                fee: FEE,
+                ttl: TTL,
+                protocolMagic: PROTOCOL_MAGICS['mainnet'],
+                networkId: NETWORK_IDS['mainnet'],
+            },
+            result: {
+                hash: 'd1610bb89bece22ed3158738bc1fbb31c6af0685053e2993361e3380f49afad9',
+                serializedTx: '83a400818258203b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b700018282583901eb0baa5e570cffbe2934db29df0b6a3d7c0430ee65d4c3a7ab2fefb91bc428e4720702ebd5dab4fb175324c192dc9bb76cc5da956e3c8dff018258390180f9e2c88e6c817008f3a812ed889b4a4da8e0bd103f86e7335422aa32c728d3861e164cab28cb8f006448139c8f1740ffb8e7aa9e5232dc1a006ca79302182a030aa100818258205d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c15840622f22d03bc9651ddc5eb2f5dc709ac4240a64d2b78c70355dd62106543c407d56e8134c4df7884ba67c8a1b5c706fc021df5c4d0ff37385c30572e73c727d00f6',
+            },
+        },
+
+        {
+            description: 'signMainnetPointerAddress',
+            params: {
+                inputs: [SAMPLE_INPUTS['shelley_input']],
+                outputs: [
+                    SAMPLE_OUTPUTS['simple_shelley_output'],
+                    SAMPLE_OUTPUTS['pointer_address_output'],
+                ],
+                fee: FEE,
+                ttl: TTL,
+                protocolMagic: PROTOCOL_MAGICS['mainnet'],
+                networkId: NETWORK_IDS['mainnet'],
+            },
+            result: {
+                hash: '40535fa8f88515f1da008d3cdf544cf9dbf1675c3cb0adb13b74b9293f1b7096',
+                serializedTx: '83a400818258203b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b700018282583901eb0baa5e570cffbe2934db29df0b6a3d7c0430ee65d4c3a7ab2fefb91bc428e4720702ebd5dab4fb175324c192dc9bb76cc5da956e3c8dff018258204180f9e2c88e6c817008f3a812ed889b4a4da8e0bd103f86e7335422aa0102031a006ca79302182a030aa100818258205d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c15840dbbf050cc13d0696b1884113613318a275e6f0f8c7cb3e7828c4f2f3c158b2622a5d65ea247f1eed758a0f6242a52060c319d6f37c8460f5d14be24456cd0b08f6',
+            },
+        },
+
+        {
+            description: 'signMainnetEnterpriseAddress',
+            params: {
+                inputs: [SAMPLE_INPUTS['shelley_input']],
+                outputs: [
+                    SAMPLE_OUTPUTS['simple_shelley_output'],
+                    SAMPLE_OUTPUTS['enterprise_address_output'],
+                ],
+                fee: FEE,
+                ttl: TTL,
+                protocolMagic: PROTOCOL_MAGICS['mainnet'],
+                networkId: NETWORK_IDS['mainnet'],
+            },
+            result: {
+                hash: 'd3570557b197604109481a80aeb66cd2cfabc57f802ad593bacc12eb658e5d72',
+                serializedTx: '83a400818258203b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b700018282583901eb0baa5e570cffbe2934db29df0b6a3d7c0430ee65d4c3a7ab2fefb91bc428e4720702ebd5dab4fb175324c192dc9bb76cc5da956e3c8dff0182581d6180f9e2c88e6c817008f3a812ed889b4a4da8e0bd103f86e7335422aa1a006ca79302182a030aa100818258205d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c15840c5996650c438c4493b2c8a94229621bb9b151b8d61d75fb868c305e917031e9a1654f35023f7dbf5d1839ab9d57b153c7f79c2666af51ecf363780397956e00af6',
+            },
+        },
+
+        {
             description: 'signTestnet',
             params: {
-                inputs: [SAMPLE_INPUT],
+                inputs: [SAMPLE_INPUTS['byron_input']],
                 outputs: [
                     SAMPLE_OUTPUTS['testnet_output'],
-                    SAMPLE_OUTPUTS['change_output'],
+                    SAMPLE_OUTPUTS['shelley_testnet_output'],
+                    SAMPLE_OUTPUTS['byron_change_output'],
                 ],
                 fee: FEE,
                 ttl: TTL,
                 protocolMagic: PROTOCOL_MAGICS['testnet'],
+                networkId: NETWORK_IDS['testnet'],
             },
             result: {
-                hash: '5dd03fb44cb88061b2a1c246981bb31adfe4f57be69b58badb5ae8f448450932',
-                serializedTx: '83a400818258201af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc00018282582f82d818582583581c586b90cf80c021db288ce1c18ecfd3610acf64f8748768b0eb7335b1a10242182a001aae3129311a002dd2e882582f82d818582583581c98c3a558f39d1d993cc8770e8825c70a6d0f5a9eb243501c4526c29da10242182a001aa8566c011a000f424002182a030aa1028184582089053545a6c254b0d9b1464e48d2b5fcf91d4e25c128afb1fcfc61d0843338ea5840fc30afdd0d4a6d8581e0f6abe895994d208fd382f2b23ff1553d711477a4fedbd1f68a76e7465c4816d5477f4287f7360acf71fca3b3d5902e4448e48c447106582026308151516f3b0e02bb1638142747863c520273ce9bd3e5cd91e1d46fe2a63545a10242182af6',
+                hash: '47cf79f20c6c62edb4162b3b232a57afc1bd0b57c7fd8389555276408a004776',
+                serializedTx: '83a400818258201af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc00018382582f82d818582583581cc817d85b524e3d073795819a25cdbb84cff6aa2bbb3a081980d248cba10242182a001a0fb6fc611a002dd2e882581d60cb03849e268f989b5a843107bad7fa2908246986a8f3d643f8c184800182582f82d818582583581c98c3a558f39d1d993cc8770e8825c70a6d0f5a9eb243501c4526c29da10242182a001aa8566c011a000f424002182a030aa1028184582089053545a6c254b0d9b1464e48d2b5fcf91d4e25c128afb1fcfc61d0843338ea5840cc11adf81cb3c3b75a438325f8577666f5cbb4d5d6b73fa6dbbcf5ab36897df34eecacdb54c3bc3ce7fc594ebb2c7aa4db4700f4290facad9b611a035af8710a582026308151516f3b0e02bb1638142747863c520273ce9bd3e5cd91e1d46fe2a63545a10242182af6',
             },
         },
-
     ],
 };


### PR DESCRIPTION
The types are based on [this protobuf file](https://github.com/trezor/trezor-firmware/blob/741fca01567151fa9dad2e9d25db7236169fb697/common/protob/messages-cardano.proto).

**EDIT: Adding message from PR 1:**
I'm struggling with the nested types and I am not sure about the way I'm dealing with them in the code. I've only so far done `CardanoGetAddress`. The functional tests do pass, so it works (other tests are not yet complete).

However, I am not sure about the correctness of the code, since e.g `CardanoAddressParameters.path` is of type `string | number[]` although when returning the address (`CardanoAddress`) it should be strictly `number[]` as `path` was before. Could you please take a look at it and provide some guidance? 