### PR TITLE
Cardano allow transactions without outputs

### DIFF
--- a/docs/methods/cardanoSignTransaction.md
+++ b/docs/methods/cardanoSignTransaction.md
@@ -28,7 +28,19 @@ TrezorConnect.cardanoSignTransaction(params).then(function(result) {
 * `withdrawals` - *optional* `Array` of [CardanoWithdrawal](../../src/js/types/networks/cardano.js#L88)
 * `metadata` - *optional* `String`
 
+### Stake pool registration certificate specifics
+
+Trezor supports signing of stake pool registration certificates as a pool owner. The transaction may contain external inputs (e.g. belonging to the pool operator) and Trezor is not able verify whether they are actually external or not, so if we allowed signing the transaction with a spending key, there is the risk of losing funds from an input that the user did not intend to spend from. Moreover there is the risk of inadvertedly signing a withdrawal in the transaction if there's any. To mitigate those risks, we introduced special validation rules for stake pool registration transactions which are validated on Trezor as well. The validation rules are the following:
+
+1. The transaction must not contain any other certificates, not even another stake pool registration
+2. The transaction must not contain any withdrawals
+3. The transaction inputs must all be external, i.e. path must be either undefined or null
+4. Exactly one owner should be passed as a staking path and the rest of owners should be passed as bech32-encoded reward addresses
+
 ### Example
+
+
+#### Ordinary transaction
 ```javascript
 TrezorConnect.cardanoSignTransaction({
     inputs: [
@@ -78,6 +90,82 @@ TrezorConnect.cardanoSignTransaction({
     metadata: "a200a11864a118c843aa00ff01a119012c590100aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     protocolMagic: 764824073,
     networkId: 1,
+});
+```
+
+#### Stake pool registration
+```javascript
+TrezorConnect.cardanoSignTransaction({
+    inputs: [
+        {
+            // notice no path is provided here
+            prev_hash: '3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7',
+            prev_index: 0,
+        }
+    ],
+    outputs: {
+        address: 'addr1q84sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlsd5tq5r',
+        amount: '1000000',
+    },
+    fee: "300000",
+    ttl: "500000000",
+    protocolMagic: 764824073,
+    networkId: 1,
+    certificates: [
+        {
+            type: 3, // stake pool registration certificate type
+            poolParameters: {
+                poolId: "f61c42cbf7c8c53af3f520508212ad3e72f674f957fe23ff0acb4973",
+                vrfKeyHash: "198890ad6c92e80fbdab554dda02da9fb49d001bbd96181f3e07f7a6ab0d0640",
+                pledge: "500000000", // amount in lovelace
+                cost: "340000000", // amount in lovelace
+                margin: { // numerator/denominator should be <= 1 which is translated then to a percentage
+                    numerator: "1",
+                    denominator: "2",
+                },
+                rewardAccount: "stake1uya87zwnmax0v6nnn8ptqkl6ydx4522kpsc3l3wmf3yswygwx45el", // bech32-encoded stake pool reward account
+                owners: [
+                    {
+                        stakingKeyPath: "m/1852'/1815'/0'/2/0" // this is the path to the owner's key that will be signing the tx on Trezor
+                    },
+                    {
+                        stakingKeyHash: "3a7f09d3df4cf66a7399c2b05bfa234d5a29560c311fc5db4c490711" // other owner
+                    }
+                ],
+                relays: [
+                    {
+                        type: 0, // single host ip address
+                        ipv4Address: "192.168.0.1",
+                        ipv6Address: "2001:0db8:85a3:0000:0000:8a2e:0370:7334", // ipv6 address in full form
+                        port: 1234
+                    },
+                    {
+                        type: 0,
+                        ipv6Address: "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+                        port: 1234
+                    },
+                    {
+                        type: 0,
+                        ipv4Address: "192.168.0.1",
+                        port: 1234
+                    },
+                    {
+                        type: 1, // single hostname
+                        hostName: "www.test.test",
+                        port: 1234
+                    },
+                    {
+                        type: 2, // multiple host names
+                        hostName: "www.test2.test" // max 64 characters long
+                    }
+                ],
+                metadata: {
+                    url: "https://www.test.test", // max 64 characters long
+                    hash: "914c57c1f12bbf4a82b12d977d4f274674856a11ed4b9b95bd70f5d41c5064a6"
+                }
+            }
+        }
+    ],
 });
 ```
 

--- a/src/data/messages/messages.json
+++ b/src/data/messages/messages.json
@@ -1821,6 +1821,175 @@
                     "oneofs": {}
                 },
                 {
+                    "name": "CardanoPoolOwnerType",
+                    "fields": [
+                        {
+                            "rule": "repeated",
+                            "options": {},
+                            "type": "uint32",
+                            "name": "staking_key_path",
+                            "id": 1
+                        },
+                        {
+                            "rule": "optional",
+                            "options": {},
+                            "type": "bytes",
+                            "name": "staking_key_hash",
+                            "id": 2
+                        }
+                    ],
+                    "enums": [],
+                    "messages": [],
+                    "options": {},
+                    "oneofs": {}
+                },
+                {
+                    "name": "CardanoPoolRelayParametersType",
+                    "fields": [
+                        {
+                            "rule": "optional",
+                            "options": {},
+                            "type": "CardanoPoolRelayType",
+                            "name": "type",
+                            "id": 1
+                        },
+                        {
+                            "rule": "optional",
+                            "options": {},
+                            "type": "bytes",
+                            "name": "ipv4_address",
+                            "id": 2
+                        },
+                        {
+                            "rule": "optional",
+                            "options": {},
+                            "type": "bytes",
+                            "name": "ipv6_address",
+                            "id": 3
+                        },
+                        {
+                            "rule": "optional",
+                            "options": {},
+                            "type": "string",
+                            "name": "host_name",
+                            "id": 4
+                        },
+                        {
+                            "rule": "optional",
+                            "options": {},
+                            "type": "uint32",
+                            "name": "port",
+                            "id": 5
+                        }
+                    ],
+                    "enums": [],
+                    "messages": [],
+                    "options": {},
+                    "oneofs": {}
+                },
+                {
+                    "name": "CardanoPoolMetadataType",
+                    "fields": [
+                        {
+                            "rule": "optional",
+                            "options": {},
+                            "type": "string",
+                            "name": "url",
+                            "id": 1
+                        },
+                        {
+                            "rule": "optional",
+                            "options": {},
+                            "type": "bytes",
+                            "name": "hash",
+                            "id": 2
+                        }
+                    ],
+                    "enums": [],
+                    "messages": [],
+                    "options": {},
+                    "oneofs": {}
+                },
+                {
+                    "name": "CardanoPoolParametersType",
+                    "fields": [
+                        {
+                            "rule": "optional",
+                            "options": {},
+                            "type": "bytes",
+                            "name": "pool_id",
+                            "id": 1
+                        },
+                        {
+                            "rule": "optional",
+                            "options": {},
+                            "type": "bytes",
+                            "name": "vrf_key_hash",
+                            "id": 2
+                        },
+                        {
+                            "rule": "optional",
+                            "options": {},
+                            "type": "uint64",
+                            "name": "pledge",
+                            "id": 3
+                        },
+                        {
+                            "rule": "optional",
+                            "options": {},
+                            "type": "uint64",
+                            "name": "cost",
+                            "id": 4
+                        },
+                        {
+                            "rule": "optional",
+                            "options": {},
+                            "type": "uint64",
+                            "name": "margin_numerator",
+                            "id": 5
+                        },
+                        {
+                            "rule": "optional",
+                            "options": {},
+                            "type": "uint64",
+                            "name": "margin_denominator",
+                            "id": 6
+                        },
+                        {
+                            "rule": "optional",
+                            "options": {},
+                            "type": "string",
+                            "name": "reward_account",
+                            "id": 7
+                        },
+                        {
+                            "rule": "repeated",
+                            "options": {},
+                            "type": "CardanoPoolOwnerType",
+                            "name": "owners",
+                            "id": 8
+                        },
+                        {
+                            "rule": "repeated",
+                            "options": {},
+                            "type": "CardanoPoolRelayParametersType",
+                            "name": "relays",
+                            "id": 9
+                        },
+                        {
+                            "rule": "optional",
+                            "options": {},
+                            "type": "CardanoPoolMetadataType",
+                            "name": "metadata",
+                            "id": 10
+                        }
+                    ],
+                    "enums": [],
+                    "messages": [],
+                    "options": {},
+                    "oneofs": {}
+                },
+                {
                     "name": "CardanoTxCertificateType",
                     "fields": [
                         {
@@ -1843,6 +2012,13 @@
                             "type": "bytes",
                             "name": "pool",
                             "id": 3
+                        },
+                        {
+                            "rule": "optional",
+                            "options": {},
+                            "type": "CardanoPoolParametersType",
+                            "name": "pool_parameters",
+                            "id": 4
                         }
                     ],
                     "enums": [],
@@ -9725,6 +9901,28 @@
                 },
                 {
                     "name": "STAKE_DELEGATION",
+                    "id": 2
+                },
+                {
+                    "name": "STAKE_POOL_REGISTRATION",
+                    "id": 3
+                }
+            ],
+            "options": {}
+        },
+        {
+            "name": "CardanoPoolRelayType",
+            "values": [
+                {
+                    "name": "SINGLE_HOST_IP",
+                    "id": 0
+                },
+                {
+                    "name": "SINGLE_HOST_NAME",
+                    "id": 1
+                },
+                {
+                    "name": "MULTIPLE_HOST_NAME",
                     "id": 2
                 }
             ],

--- a/src/js/constants/cardano.js
+++ b/src/js/constants/cardano.js
@@ -22,4 +22,11 @@ export const CERTIFICATE_TYPE = Object.freeze({
     StakeRegistration: 0,
     StakeDeregistration: 1,
     StakeDelegation: 2,
+    StakePoolRegistration: 3,
+});
+
+export const POOL_RELAY_TYPE = Object.freeze({
+    SingleHostIp: 0,
+    SingleHostName: 1,
+    MultipleHostName: 2,
 });

--- a/src/js/core/methods/CardanoSignTransaction.js
+++ b/src/js/core/methods/CardanoSignTransaction.js
@@ -5,6 +5,7 @@ import { validateParams, getFirmwareRange } from './helpers/paramsValidator';
 import { getMiscNetwork } from '../../data/CoinInfo';
 import { validatePath } from '../../utils/pathUtils';
 import { addressParametersToProto, validateAddressParameters } from './helpers/cardanoAddressParameters';
+import { transformCertificate } from './helpers/cardanoCertificate';
 
 import type {
     CardanoTxCertificate,
@@ -52,12 +53,11 @@ export default class CardanoSignTransaction extends AbstractMethod {
 
         const inputs: Array<CardanoTxInput> = payload.inputs.map(input => {
             validateParams(input, [
-                { name: 'path', obligatory: true },
                 { name: 'prev_hash', type: 'string', obligatory: true },
                 { name: 'prev_index', type: 'number', obligatory: true },
             ]);
             return {
-                address_n: validatePath(input.path, 5),
+                address_n: input.path ? validatePath(input.path, 5) : undefined,
                 prev_hash: input.prev_hash,
                 prev_index: input.prev_index,
                 type: input.type,
@@ -86,18 +86,7 @@ export default class CardanoSignTransaction extends AbstractMethod {
 
         let certificates: Array<CardanoTxCertificate> = [];
         if (payload.certificates) {
-            certificates = payload.certificates.map(certificate => {
-                validateParams(certificate, [
-                    { name: 'type', type: 'number', obligatory: true },
-                    { name: 'path', obligatory: true },
-                    { name: 'pool', type: 'string' },
-                ]);
-                return {
-                    type: certificate.type,
-                    path: validatePath(certificate.path, 5),
-                    pool: certificate.pool,
-                };
-            });
+            certificates = payload.certificates.map(transformCertificate);
         }
 
         let withdrawals: Array<CardanoTxWithdrawal> = [];

--- a/src/js/core/methods/CardanoSignTransaction.js
+++ b/src/js/core/methods/CardanoSignTransaction.js
@@ -41,7 +41,7 @@ export default class CardanoSignTransaction extends AbstractMethod {
         // validate incoming parameters
         validateParams(payload, [
             { name: 'inputs', type: 'array', obligatory: true },
-            { name: 'outputs', type: 'array', obligatory: true },
+            { name: 'outputs', type: 'array', obligatory: true, allowEmpty: true },
             { name: 'fee', type: 'string', obligatory: true },
             { name: 'ttl', type: 'string', obligatory: true },
             { name: 'certificates', type: 'array', allowEmpty: true },

--- a/src/js/core/methods/helpers/cardanoCertificate.js
+++ b/src/js/core/methods/helpers/cardanoCertificate.js
@@ -1,0 +1,180 @@
+/* @flow */
+
+import { validateParams } from './paramsValidator';
+import { CERTIFICATE_TYPE, POOL_RELAY_TYPE } from '../../../constants/cardano';
+import { validatePath } from '../../../utils/pathUtils';
+import { ERRORS } from '../../../constants';
+
+import type {
+    CardanoCertificate,
+    CardanoPoolParameters,
+    CardanoPoolMargin,
+    CardanoPoolOwner,
+    CardanoPoolRelay,
+    CardanoPoolMetadata,
+} from '../../../types/networks/cardano';
+
+import type {
+    CardanoTxCertificate,
+    CardanoPoolParameters as CardanoPoolParametersMessage,
+    CardanoPoolOwner as CardanoPoolOwnerMessage,
+    CardanoPoolRelay as CardanoPoolRelayMessage,
+} from '../../../types/trezor/protobuf';
+
+const ipv4AddressToHex = (ipv4Address: string): string => {
+    return Buffer.from(ipv4Address.split('.').map((ipPart) => parseInt(ipPart))).toString('hex');
+};
+
+const ipv6AddressToHex = (ipv6Address: string): string => {
+    return ipv6Address.split(':').join('');
+};
+
+const validatePoolMargin = (margin: CardanoPoolMargin) => {
+    validateParams(margin, [
+        { name: 'numerator', type: 'string', obligatory: true },
+        { name: 'denominator', type: 'string', obligatory: true },
+    ]);
+};
+
+const validatePoolMetadata = (metadata: CardanoPoolMetadata) => {
+    validateParams(metadata, [
+        { name: 'url', type: 'string', obligatory: true },
+        { name: 'hash', type: 'string', obligatory: true },
+    ]);
+};
+
+const validatePoolRelay = (relay: CardanoPoolRelay) => {
+    validateParams(relay, [
+        { name: 'type', type: 'number', obligatory: true },
+    ]);
+
+    if (relay.type === POOL_RELAY_TYPE.SingleHostIp) {
+        const paramsToValidate = [
+            { name: 'port', type: 'number', obligatory: true },
+        ];
+        if (relay.ipv4Address) {
+            paramsToValidate.push({ name: 'ipv4Address', type: 'string' });
+        }
+        if (relay.ipv6Address) {
+            paramsToValidate.push({ name: 'ipv6Address', type: 'string' });
+        }
+
+        validateParams(relay, paramsToValidate);
+
+        if (!relay.ipv4Address && !relay.ipv6Address) {
+            throw ERRORS.TypedError('Method_InvalidParameter', 'Either ipv4Address or ipv6Address must be supplied');
+        }
+    } else if (relay.type === POOL_RELAY_TYPE.SingleHostName) {
+        validateParams(relay, [
+            { name: 'hostName', type: 'string', obligatory: true },
+            { name: 'port', type: 'number', obligatory: true },
+        ]);
+    } else if (POOL_RELAY_TYPE.MultipleHostName) {
+        validateParams(relay, [
+            { name: 'hostName', type: 'string', obligatory: true },
+        ]);
+    }
+};
+
+const validatePoolOwners = (owners: Array<CardanoPoolOwner>) => {
+    owners.forEach((owner) => {
+        if (owner.stakingKeyHash) {
+            validateParams(owner, [
+                { name: 'stakingKeyHash', type: 'string', obligatory: !owner.stakingKeyPath },
+            ]);
+        }
+
+        if (owner.stakingKeyPath) {
+            validatePath(owner.stakingKeyPath, 5);
+        }
+
+        if (!owner.stakingKeyHash && !owner.stakingKeyPath) {
+            throw ERRORS.TypedError('Method_InvalidParameter', 'Either stakingKeyHash or stakingKeyPath must be supplied');
+        }
+    });
+
+    const ownersAsPathCount = owners.filter(owner => !!owner.stakingKeyPath).length;
+    if (ownersAsPathCount !== 1) {
+        throw ERRORS.TypedError('Method_InvalidParameter', 'Exactly one pool owner must be given as a path');
+    }
+};
+
+const validatePoolParameters = (poolParameters: CardanoPoolParameters) => {
+    validateParams(poolParameters, [
+        { name: 'poolId', type: 'string', obligatory: true },
+        { name: 'vrfKeyHash', type: 'string', obligatory: true },
+        { name: 'pledge', type: 'string', obligatory: true },
+        { name: 'cost', type: 'string', obligatory: true },
+        { name: 'margin', type: 'object', obligatory: true },
+        { name: 'rewardAccount', type: 'string', obligatory: true },
+        { name: 'owners', type: 'array', obligatory: true },
+        { name: 'relays', type: 'array', obligatory: true, allowEmpty: true },
+        { name: 'metadata', type: 'object' },
+    ]);
+
+    validatePoolMargin(poolParameters.margin);
+    validatePoolOwners(poolParameters.owners);
+    poolParameters.relays.forEach(validatePoolRelay);
+
+    if (poolParameters.metadata) {
+        validatePoolMetadata(poolParameters.metadata);
+    }
+};
+
+const transformPoolParameters = (poolParameters: CardanoPoolParameters): CardanoPoolParametersMessage => {
+    validatePoolParameters(poolParameters);
+
+    return {
+        pool_id: poolParameters.poolId,
+        vrf_key_hash: poolParameters.vrfKeyHash,
+        pledge: poolParameters.pledge,
+        cost: poolParameters.cost,
+        margin_numerator: poolParameters.margin.numerator,
+        margin_denominator: poolParameters.margin.denominator,
+        reward_account: poolParameters.rewardAccount,
+        owners: poolParameters.owners.map((owner: CardanoPoolOwner): CardanoPoolOwnerMessage => {
+            return {
+                staking_key_hash: owner.stakingKeyHash,
+                staking_key_path: owner.stakingKeyPath ? validatePath(owner.stakingKeyPath, 5) : undefined,
+            };
+        }),
+        relays: poolParameters.relays.map((relay: CardanoPoolRelay): CardanoPoolRelayMessage => {
+            return {
+                type: relay.type,
+                ipv4_address: relay.ipv4Address ? ipv4AddressToHex(relay.ipv4Address) : undefined,
+                ipv6_address: relay.ipv6Address ? ipv6AddressToHex(relay.ipv6Address) : undefined,
+                host_name: relay.hostName,
+                port: relay.port,
+            };
+        }),
+        metadata: poolParameters.metadata,
+    };
+};
+
+// transform incoming certificate object to protobuf messages format
+export const transformCertificate = (certificate: CardanoCertificate): CardanoTxCertificate => {
+    const paramsToValidate = [
+        { name: 'type', type: 'number', obligatory: true },
+    ];
+
+    if (certificate.type !== CERTIFICATE_TYPE.StakePoolRegistration) {
+        paramsToValidate.push({ name: 'path', obligatory: true });
+    }
+
+    if (certificate.type === CERTIFICATE_TYPE.StakeDelegation) {
+        paramsToValidate.push({ name: 'pool', type: 'string', obligatory: true });
+    }
+
+    if (certificate.type === CERTIFICATE_TYPE.StakePoolRegistration) {
+        paramsToValidate.push({ name: 'poolParameters', type: 'object', obligatory: true });
+    }
+
+    validateParams(certificate, paramsToValidate);
+
+    return {
+        type: certificate.type,
+        path: certificate.path ? validatePath(certificate.path, 5) : undefined,
+        pool: certificate.pool,
+        pool_parameters: certificate.poolParameters ? transformPoolParameters(certificate.poolParameters) : undefined,
+    };
+};

--- a/src/js/types/networks/cardano.js
+++ b/src/js/types/networks/cardano.js
@@ -59,7 +59,7 @@ export type CardanoAddress = {
 export type CardanoCertificateType = $Values<typeof CERTIFICATE_TYPE>;
 
 export type CardanoInput = {
-    path: string | number[];
+    path?: string | number[];
     prev_hash: string;
     prev_index: number;
 }
@@ -70,11 +70,49 @@ export type CardanoOutput = {
     address: string;
     amount: string;
 }
+
+export type CardanoPoolOwner = {
+    stakingKeyPath?: string | number[];
+    stakingKeyHash?: string;
+}
+
+export type CardanoPoolRelay = {
+    type: number;
+    ipv4Address?: string;
+    ipv6Address?: string;
+    port?: number;
+    hostName?: string;
+}
+
+export type CardanoPoolMetadata = {
+    url: string;
+    hash: string;
+}
+
+export type CardanoPoolMargin = {
+    numerator: string;
+    denominator: string;
+}
+
+export type CardanoPoolParameters = {
+    poolId: string;
+    vrfKeyHash: string;
+    pledge: string;
+    cost: string;
+    margin: CardanoPoolMargin;
+    rewardAccount: string;
+    owners: CardanoPoolOwner[];
+    relays: CardanoPoolRelay[];
+    metadata: CardanoPoolMetadata;
+}
+
 export type CardanoCertificate = {
     type: CardanoCertificateType;
-    path: string | number[];
+    path?: string | number[];
     pool?: string;
+    poolParameters?: CardanoPoolParameters;
 }
+
 export type CardanoWithdrawal = {
     path: string | number[];
     amount: string;

--- a/src/js/types/trezor/protobuf.js
+++ b/src/js/types/trezor/protobuf.js
@@ -602,7 +602,7 @@ export type CardanoSignedTx = {
 };
 export type CardanoTxInput = {
     tx_hash: string;
-    address_n: Array<number>;
+    address_n?: Array<number>;
     output_index: number;
 };
 export type CardanoTxOutput = {
@@ -610,11 +610,44 @@ export type CardanoTxOutput = {
     address_parameters?: CardanoAddressParameters;
     amount: string;
 };
+
+export type CardanoPoolOwner = {
+    staking_key_hash?: string;
+    staking_key_path?: Array<number>;
+}
+
+export type CardanoPoolRelay = {
+    type: number;
+    ipv4_address?: string;
+    ipv6_address?: string;
+    host_name?: string;
+    port?: number;
+}
+
+export type CardanoPoolMetadata = {
+    url: string;
+    hash: string;
+}
+
+export type CardanoPoolParameters = {
+    pool_id: string;
+    vrf_key_hash: string;
+    pledge: string;
+    cost: string;
+    margin_numerator: string;
+    margin_denominator: string;
+    reward_account: string;
+    owners: Array<CardanoPoolOwner>;
+    relays: Array<CardanoPoolRelay>;
+    metadata: CardanoPoolMetadata;
+};
 export type CardanoTxCertificate = {
     type: number;
-    path: Array<number>;
+    path?: Array<number>;
     pool?: string;
+    pool_parameters?: CardanoPoolParameters;
 };
+
 export type CardanoTxWithdrawal = {
     path: Array<number>;
     amount: string;

--- a/src/ts/types/constants.d.ts
+++ b/src/ts/types/constants.d.ts
@@ -167,5 +167,6 @@ export namespace CARDANO {
         StakeRegistration = 0,
         StakeDeregistration = 1,
         StakeDelegation = 2,
+        StakePoolRegistration = 3
     }
 }

--- a/tests/__fixtures__/cardanoSignTransaction.js
+++ b/tests/__fixtures__/cardanoSignTransaction.js
@@ -18,6 +18,11 @@ const SAMPLE_INPUTS = {
         prev_hash: '3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7',
         prev_index: 0,
     },
+    external_input: {
+        path: undefined,
+        prev_hash: '3b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b7',
+        prev_index: 0,
+    },
 };
 
 const SAMPLE_OUTPUTS = {
@@ -105,8 +110,84 @@ const SAMPLE_CERTIFICATES = {
     stake_delegation: {
         type: CERTIFICATE_TYPE.StakeDelegation,
         path: "m/1852'/1815'/0'/2/0",
-        pool: 'f61c42cbf7c8c53af3f520508212ad3e72f674f957fe23ff0acb4973',
+        pool: "f61c42cbf7c8c53af3f520508212ad3e72f674f957fe23ff0acb4973",
     },
+    stake_pool_registration: {
+        type: CERTIFICATE_TYPE.StakePoolRegistration,
+        poolParameters: {
+            poolId: "f61c42cbf7c8c53af3f520508212ad3e72f674f957fe23ff0acb4973",
+            vrfKeyHash: "198890ad6c92e80fbdab554dda02da9fb49d001bbd96181f3e07f7a6ab0d0640",
+            pledge: "500000000",
+            cost: "340000000",
+            margin: {
+                numerator: "1",
+                denominator: "2",
+            },
+            rewardAccount: "stake1uya87zwnmax0v6nnn8ptqkl6ydx4522kpsc3l3wmf3yswygwx45el",
+            owners: [
+                {
+                    stakingKeyPath: "m/1852'/1815'/0'/2/0",
+                    stakingKeyHash: undefined,
+                },
+                {
+                    stakingKeyHash: "3a7f09d3df4cf66a7399c2b05bfa234d5a29560c311fc5db4c490711"
+                }
+            ],
+            relays: [
+                {
+                    type: 0,
+                    ipv4Address: "192.168.0.1",
+                    ipv6Address: "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+                    port: 1234
+                },
+                {
+                    type: 0,
+                    ipv6Address: "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+                    ipv4Address: null,
+                    port: 1234
+                },
+                {
+                    type: 0,
+                    ipv4Address: "192.168.0.1",
+                    port: 1234
+                },
+                {
+                    type: 1,
+                    hostName: "www.test.test",
+                    port: 1234
+                },
+                {
+                    type: 2,
+                    hostName: "www.test2.test"
+                }
+            ],
+            metadata: {
+                url: "https://www.test.test",
+                hash: "914c57c1f12bbf4a82b12d977d4f274674856a11ed4b9b95bd70f5d41c5064a6"
+            }
+        }
+    },
+    stake_pool_registration_no_metadata: {
+        type: CERTIFICATE_TYPE.StakePoolRegistration,
+        poolParameters: {
+            poolId: "f61c42cbf7c8c53af3f520508212ad3e72f674f957fe23ff0acb4973",
+            vrfKeyHash: "198890ad6c92e80fbdab554dda02da9fb49d001bbd96181f3e07f7a6ab0d0640",
+            pledge: "500000000",
+            cost: "340000000",
+            margin: {
+                numerator: "1",
+                denominator: "2",
+            },
+            rewardAccount: "stake1uya87zwnmax0v6nnn8ptqkl6ydx4522kpsc3l3wmf3yswygwx45el",
+            owners: [
+                {
+                    stakingKeyPath: "m/1852'/1815'/0'/2/0"
+                },
+            ],
+            relays: [],
+            metadata: null,
+        }
+    }
 };
 
 const SAMPLE_WITHDRAWAL = {
@@ -359,6 +440,42 @@ export default {
             result: {
                 hash: '47cf79f20c6c62edb4162b3b232a57afc1bd0b57c7fd8389555276408a004776',
                 serializedTx: '83a400818258201af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc00018382582f82d818582583581cc817d85b524e3d073795819a25cdbb84cff6aa2bbb3a081980d248cba10242182a001a0fb6fc611a002dd2e882581d60cb03849e268f989b5a843107bad7fa2908246986a8f3d643f8c184800182582f82d818582583581c98c3a558f39d1d993cc8770e8825c70a6d0f5a9eb243501c4526c29da10242182a001aa8566c011a000f424002182a030aa1028184582089053545a6c254b0d9b1464e48d2b5fcf91d4e25c128afb1fcfc61d0843338ea5840cc11adf81cb3c3b75a438325f8577666f5cbb4d5d6b73fa6dbbcf5ab36897df34eecacdb54c3bc3ce7fc594ebb2c7aa4db4700f4290facad9b611a035af8710a582026308151516f3b0e02bb1638142747863c520273ce9bd3e5cd91e1d46fe2a63545a10242182af6',
+            },
+        },
+        {
+            description: 'signStakePoolRegistration',
+            params: {
+                inputs: [SAMPLE_INPUTS['external_input']],
+                outputs: [
+                    SAMPLE_OUTPUTS['simple_shelley_output'],
+                ],
+                fee: FEE,
+                ttl: TTL,
+                protocolMagic: PROTOCOL_MAGICS['mainnet'],
+                networkId: NETWORK_IDS['mainnet'],
+                certificates: [SAMPLE_CERTIFICATES['stake_pool_registration']],
+            },
+            result: {
+                hash: 'e3b9a5657bf62609465a930c8359d774c73944973cfc5a104a0f0ed1e1e8db21',
+                serializedTx: '83a500818258203b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b700018182583901eb0baa5e570cffbe2934db29df0b6a3d7c0430ee65d4c3a7ab2fefb91bc428e4720702ebd5dab4fb175324c192dc9bb76cc5da956e3c8dff0102182a030a04818a03581cf61c42cbf7c8c53af3f520508212ad3e72f674f957fe23ff0acb49735820198890ad6c92e80fbdab554dda02da9fb49d001bbd96181f3e07f7a6ab0d06401a1dcd65001a1443fd00d81e820102581de13a7f09d3df4cf66a7399c2b05bfa234d5a29560c311fc5db4c49071182581c122a946b9ad3d2ddf029d3a828f0468aece76895f15c9efbd69b4277581c3a7f09d3df4cf66a7399c2b05bfa234d5a29560c311fc5db4c4907118584001904d244c0a8000150b80d01200000a3852e8a00003473700384001904d2f650b80d01200000a3852e8a00003473700384001904d244c0a80001f683011904d26d7777772e746573742e7465737482026e7777772e74657374322e74657374827568747470733a2f2f7777772e746573742e746573745820914c57c1f12bbf4a82b12d977d4f274674856a11ed4b9b95bd70f5d41c5064a6a10081825820bc65be1b0b9d7531778a1317c2aa6de936963c3f9ac7d5ee9e9eda25e0c97c5e584006305b52f76d2d2da6925c02036a9a28456976009f8c6432513f273110d09ea26db79c696cec322b010e5cbb7d90a6b473b157e65df846a1487062569a5f5a04f6',
+            },
+        },
+        {
+            description: 'signStakePoolRegistrationNoMetadata',
+            params: {
+                inputs: [SAMPLE_INPUTS['external_input']],
+                outputs: [
+                    SAMPLE_OUTPUTS['simple_shelley_output'],
+                ],
+                fee: FEE,
+                ttl: TTL,
+                protocolMagic: PROTOCOL_MAGICS['mainnet'],
+                networkId: NETWORK_IDS['mainnet'],
+                certificates: [SAMPLE_CERTIFICATES['stake_pool_registration_no_metadata']],
+            },
+            result: {
+                hash: '504f9214142996e0b7e315103b25d88a4afa3d01dd5be22376921b52b01483c3',
+                serializedTx: '83a500818258203b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b700018182583901eb0baa5e570cffbe2934db29df0b6a3d7c0430ee65d4c3a7ab2fefb91bc428e4720702ebd5dab4fb175324c192dc9bb76cc5da956e3c8dff0102182a030a04818a03581cf61c42cbf7c8c53af3f520508212ad3e72f674f957fe23ff0acb49735820198890ad6c92e80fbdab554dda02da9fb49d001bbd96181f3e07f7a6ab0d06401a1dcd65001a1443fd00d81e820102581de13a7f09d3df4cf66a7399c2b05bfa234d5a29560c311fc5db4c49071181581c122a946b9ad3d2ddf029d3a828f0468aece76895f15c9efbd69b427780f6a10081825820bc65be1b0b9d7531778a1317c2aa6de936963c3f9ac7d5ee9e9eda25e0c97c5e5840aa2099208399fcc27c18d7ef0c7e873f9e22f0935b7e912cddd34b33b8cafd541a878dc01c042ce490e4c9bad3c62c2f59acaa009d336c9ff875c5f153d34900f6',
             },
         },
     ],

--- a/tests/__fixtures__/cardanoSignTransaction.js
+++ b/tests/__fixtures__/cardanoSignTransaction.js
@@ -352,6 +352,23 @@ export default {
         },
 
         {
+            description: 'signStakeRegistrationNoOutputs',
+            params: {
+                inputs: [SAMPLE_INPUTS['shelley_input']],
+                outputs: [],
+                fee: FEE,
+                ttl: TTL,
+                certificates: [SAMPLE_CERTIFICATES['stake_registration']],
+                protocolMagic: PROTOCOL_MAGICS['mainnet'],
+                networkId: NETWORK_IDS['mainnet'],
+            },
+            result: {
+                hash: '03535791d04fc1b4457fada025f1c1f7778b5c2d7fa580bbac8abd53b85d3255',
+                serializedTx: '83a500818258203b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b700018002182a030a048182008200581c122a946b9ad3d2ddf029d3a828f0468aece76895f15c9efbd69b4277a100818258205d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c1584047e6e902e81bbba5596cfabaa4f9a70f36b367e28ee81181771ccd32d38b19c1d8ae9b0afb2a79057b87f8de7862e8d2317d86246909aaa66e54445d47aa990bf6',
+            },
+        },
+
+        {
             description: 'signStakeRegistrationAndDelegation',
             params: {
                 inputs: [SAMPLE_INPUTS['shelley_input']],


### PR DESCRIPTION
Motivation: allow transactions without outputs on IOHK's request. Depends on https://github.com/vacuumlabs/trezor-firmware/pull/39 to function properly - older versions of Trezor fw that don't have the aforementioned PR merged would just reject transactions without outputs and it's up to the integrating party to verify that.

This PR is a superset of https://github.com/trezor/connect/pull/695

Changes:
* update CardanoSignTransaction validation to allow an empty list of tx outputs
* add integration testscase for a tx without outputs

Testing:
* added testcase to cover changes introduced in https://github.com/vacuumlabs/trezor-firmware/pull/39 , i.e. support for transactions without outputs
* ran integration tests `yarn test:integration -b ~/workplace/cardano/trezor-firmware/core/build/unix/trezor-emu-core-v2.9.9 -f 2.9.9 -i cardanoSignTransaction` (did so on a locally rebased version upon commit https://github.com/vacuumlabs/connect/commit/1d767b2cdfc5f47f75a15393fb4305b95f69899a as I was unable to run integration tests at all on develop tip: https://github.com/trezor/connect/issues/723)