### PR TITLE
Add Cardano multiasset support

### DIFF
--- a/docs/methods/cardanoSignTransaction.md
+++ b/docs/methods/cardanoSignTransaction.md
@@ -15,17 +15,23 @@ TrezorConnect.cardanoSignTransaction(params).then(function(result) {
 });
 ```
 
+### Notes
+**Unfortunately we are aware of the fact that currently at most ~14 inputs are supported per transaction. This should be resolved when the cardano app is updated to support transaction streaming. Meanwhile, a workaround is to send multiple smaller transactions containing less inputs.**
+
+**Also, each serialized transaction output size is currently limited to 512 bytes at Trezor firmware level. This limitation is a mitigation measure to prevent sending large (especially change) outputs containing many tokens that Trezor would not be able to spend given that currently the full Cardano transaction is held in-memory. Once Cardano-transaction signing is refactored to be streamed, this limit can be lifted.**
+
 ### Params 
 [****Optional common params****](commonParams.md)
 ###### [flowtype](../../src/js/types/networks/cardano.js#L62-L109)
-* `inputs` — *obligatory* `Array` of [CardanoInput](../../src/js/types/networks/cardano.js#L71)
+* `inputs` — *obligatory* `Array` of [CardanoInput](../../src/js/types/networks/cardano.js#L61)
 * `outputs` - *obligatory* `Array` of [CardanoOutput](../../src/js/types/networks/cardano.js#L76)
 * `fee` - *obligatory* `String`
-* `ttl` - *obligatory* `String`
 * `protocolMagic` - *obligatory* `Integer` 764824073 for Mainnet, 42 for Testnet
 * `networkId` - *obligatory* `Integer` 1 for Mainnet, 0 for Testnet
-* `certificates` - *optional* `Array` of [CardanoCertificate](../../src/js/types/networks/cardano.js#L83)
-* `withdrawals` - *optional* `Array` of [CardanoWithdrawal](../../src/js/types/networks/cardano.js#L88)
+* `ttl` - *optional* `String`
+* `validityIntervalStart` - *optional* `String`
+* `certificates` - *optional* `Array` of [CardanoCertificate](../../src/js/types/networks/cardano.js#L85)
+* `withdrawals` - *optional* `Array` of [CardanoWithdrawal](../../src/js/types/networks/cardano.js#L90)
 * `metadata` - *optional* `String`
 
 ### Example
@@ -50,10 +56,26 @@ TrezorConnect.cardanoSignTransaction({
                 stakingPath: "m/1852'/1815'/0'/2/0",
             },
             amount: "7120787",
+        },
+        {
+            address: 'addr1q84sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlsd5tq5r',
+            amount: '2000000',
+            tokenBundle: [
+                {
+                    policyId: "95a292ffee938be03e9bae5657982a74e9014eb4960108c9e23a5b39",
+                    tokens: [
+                        {
+                            assetNameBytes: "74652474436f696e",
+                            amount: "7878754"
+                        }
+                    ]
+                }
+            ]
         }
     ],
     fee: "42",
     ttl: "10",
+    validityIntervalStart: "20",
     certificates: [
         {
             type: 0,
@@ -82,7 +104,7 @@ TrezorConnect.cardanoSignTransaction({
 ```
 
 ### Result
-###### [flowtype](../../src/js/types/networks/cardano.js#L105-L108)
+###### [flowtype](../../src/js/types/networks/cardano.js#L107-L110)
 ```javascript
 {
     success: true,

--- a/src/data/messages/messages.json
+++ b/src/data/messages/messages.json
@@ -1756,6 +1756,13 @@
                     "type": "bytes",
                     "name": "metadata",
                     "id": 11
+                },
+                {
+                    "rule": "optional",
+                    "options": {},
+                    "type": "uint64",
+                    "name": "validity_interval_start",
+                    "id": 12
                 }
             ],
             "enums": [],
@@ -1813,6 +1820,59 @@
                             "type": "CardanoAddressParametersType",
                             "name": "address_parameters",
                             "id": 4
+                        },
+                        {
+                            "rule": "repeated",
+                            "options": {},
+                            "type": "CardanoAssetGroupType",
+                            "name": "token_bundle",
+                            "id": 5
+                        }
+                    ],
+                    "enums": [],
+                    "messages": [],
+                    "options": {},
+                    "oneofs": {}
+                },
+                {
+                    "name": "CardanoAssetGroupType",
+                    "fields": [
+                        {
+                            "rule": "required",
+                            "options": {},
+                            "type": "bytes",
+                            "name": "policy_id",
+                            "id": 1
+                        },
+                        {
+                            "rule": "repeated",
+                            "options": {},
+                            "type": "CardanoTokenType",
+                            "name": "tokens",
+                            "id": 2
+                        }
+                    ],
+                    "enums": [],
+                    "messages": [],
+                    "options": {},
+                    "oneofs": {}
+                },
+                {
+                    "name": "CardanoTokenType",
+                    "fields": [
+                        {
+                            "rule": "required",
+                            "options": {},
+                            "type": "bytes",
+                            "name": "asset_name_bytes",
+                            "id": 1
+                        },
+                        {
+                            "rule": "required",
+                            "options": {},
+                            "type": "uint64",
+                            "name": "amount",
+                            "id": 2
                         }
                     ],
                     "enums": [],
@@ -9725,6 +9785,28 @@
                 },
                 {
                     "name": "STAKE_DELEGATION",
+                    "id": 2
+                },
+                {
+                    "name": "STAKE_POOL_REGISTRATION",
+                    "id": 3
+                }
+            ],
+            "options": {}
+        },
+        {
+            "name": "CardanoPoolRelayType",
+            "values": [
+                {
+                    "name": "SINGLE_HOST_IP",
+                    "id": 0
+                },
+                {
+                    "name": "SINGLE_HOST_NAME",
+                    "id": 1
+                },
+                {
+                    "name": "MULTIPLE_HOST_NAME",
                     "id": 2
                 }
             ],

--- a/src/js/core/methods/helpers/cardanoTokens.js
+++ b/src/js/core/methods/helpers/cardanoTokens.js
@@ -1,0 +1,43 @@
+/* @flow */
+import { validateParams } from '../helpers/paramsValidator';
+
+import type { CardanoAssetGroup as CardanoAssetGroupProto, CardanoToken as CardanoTokenProto } from '../../../types/trezor/protobuf';
+import type { CardanoAssetGroup, CardanoToken } from '../../../types/networks/cardano';
+
+const validateTokens = (tokenAmounts: CardanoToken[]) => {
+    tokenAmounts.forEach((tokenAmount) => {
+        validateParams(tokenAmount, [
+            { name: 'assetNameBytes', type: 'string', obligatory: true },
+            { name: 'amount', type: 'amount', obligatory: true },
+        ]);
+    });
+};
+
+export const validateTokenBundle = (tokenBundle: CardanoAssetGroup[]) => {
+    tokenBundle.forEach((tokenGroup) => {
+        validateParams(tokenGroup, [
+            { name: 'policyId', type: 'string', obligatory: true },
+            { name: 'tokenAmounts', type: 'array', obligatory: true },
+        ]);
+
+        validateTokens(tokenGroup.tokenAmounts);
+    });
+};
+
+const tokenAmountsToProto = (tokenAmounts: CardanoToken[]): CardanoTokenProto[] => {
+    return tokenAmounts.map((tokenAmount) => {
+        return {
+            asset_name_bytes: tokenAmount.assetNameBytes,
+            amount: tokenAmount.amount,
+        };
+    });
+};
+
+export const tokenBundleToProto = (tokenBundle: CardanoAssetGroup[]): CardanoAssetGroupProto[] => {
+    return tokenBundle.map((tokenGroup) => {
+        return {
+            policy_id: tokenGroup.policyId,
+            tokens: tokenAmountsToProto(tokenGroup.tokenAmounts),
+        };
+    });
+};

--- a/src/js/device/DeviceCommands.js
+++ b/src/js/device/DeviceCommands.js
@@ -421,12 +421,13 @@ export default class DeviceCommands {
         inputs: Array<trezor.CardanoTxInput>,
         outputs: Array<trezor.CardanoTxOutput>,
         fee: string,
-        ttl: string,
+        ttl: ?string,
         certificates: Array<trezor.CardanoTxCertificate>,
         withdrawals: Array<trezor.CardanoTxWithdrawal>,
         metadata: string,
+        validityIntervalStart: ?string,
         protocolMagic: number,
-        networkId: number
+        networkId: number,
     ): Promise<trezor.CardanoSignedTx> {
         const response: MessageResponse<trezor.CardanoSignedTx> = await this.typedCall('CardanoSignTx', 'CardanoSignedTx', {
             inputs,
@@ -436,6 +437,7 @@ export default class DeviceCommands {
             certificates,
             withdrawals,
             metadata,
+            validity_interval_start: validityIntervalStart,
             protocol_magic: protocolMagic,
             network_id: networkId,
         });

--- a/src/js/types/networks/cardano.js
+++ b/src/js/types/networks/cardano.js
@@ -63,12 +63,24 @@ export type CardanoInput = {
     prev_hash: string;
     prev_index: number;
 }
+
+export type CardanoToken = {
+    assetNameBytes: string;
+    amount: string;
+}
+
+export type CardanoAssetGroup = {
+    policyId: string;
+    tokenAmounts: CardanoToken[];
+}
 export type CardanoOutput = {
     addressParameters: CardanoAddressParameters;
     amount: string;
+    tokenBundle?: CardanoAssetGroup[];
 } | {
     address: string;
     amount: string;
+    tokenBundle?: CardanoAssetGroup[];
 }
 export type CardanoCertificate = {
     type: CardanoCertificateType;
@@ -84,10 +96,11 @@ export type CardanoSignTransaction = {
     inputs: CardanoInput[];
     outputs: CardanoOutput[];
     fee: string;
-    ttl: string;
+    ttl?: string;
     certificates?: CardanoCertificate[];
     withdrawals?: CardanoWithdrawal[];
     metadata?: string;
+    validityIntervalStart?: string;
     protocolMagic: number;
     networkId: number;
 }

--- a/src/js/types/trezor/protobuf.js
+++ b/src/js/types/trezor/protobuf.js
@@ -605,10 +605,19 @@ export type CardanoTxInput = {
     address_n: Array<number>;
     output_index: number;
 };
+export type CardanoToken = {
+    asset_name_bytes: string;
+    amount: string;
+}
+export type CardanoAssetGroup = {
+    policy_id: string;
+    tokens: CardanoToken[];
+}
 export type CardanoTxOutput = {
     address?: string;
     address_parameters?: CardanoAddressParameters;
     amount: string;
+    token_bundle: CardanoAssetGroup[];
 };
 export type CardanoTxCertificate = {
     type: number;

--- a/src/ts/types/networks/cardano.d.ts
+++ b/src/ts/types/networks/cardano.d.ts
@@ -81,10 +81,11 @@ export interface CardanoSignTransaction {
     inputs: CardanoInput[];
     outputs: CardanoOutput[];
     fee: string;
-    ttl: string;
+    ttl?: string;
     certificates?: CardanoCertificate[];
     withdrawals?: CardanoWithdrawal[];
     metadata?: string;
+    validityIntervalStart?: string;
     protocolMagic: number;
     networkId: number;
 }

--- a/src/ts/types/trezor/protobuf.d.ts
+++ b/src/ts/types/trezor/protobuf.d.ts
@@ -624,6 +624,16 @@ export interface CardanoTxOutput {
     amount: string;
 }
 
+export interface CardanoToken {
+    asset_name_bytes: string;
+    amount: string;
+};
+
+export interface CardanoAssetGroup {
+    policy_id: string;
+    tokens: CardanoToken[];
+};
+
 // Lisk types
 export interface LiskAddress {
     address: string;

--- a/tests/__fixtures__/cardanoSignTransaction.js
+++ b/tests/__fixtures__/cardanoSignTransaction.js
@@ -91,6 +91,34 @@ const SAMPLE_OUTPUTS = {
         address: 'addr_test1vr9s8py7y68e3x66sscs0wkhlg5ssfrfs65084jrlrqcfqqtmut0e',
         amount: '1',
     },
+    token_output: {
+        address: 'addr1q84sh2j72ux0l03fxndjnhctdg7hcppsaejafsa84vh7lwgmcs5wgus8qt4atk45lvt4xfxpjtwfhdmvchdf2m3u3hlsd5tq5r',
+        amount: '2000000',
+        tokenBundle: [
+            {
+                policyId: "95a292ffee938be03e9bae5657982a74e9014eb4960108c9e23a5b39",
+                tokenAmounts: [
+                    {
+                        assetNameBytes: "74652474436f696e",
+                        amount: "7878754"
+                    }
+                ],
+            },
+            {
+                policyId: "96a292ffee938be03e9bae5657982a74e9014eb4960108c9e23a5b39",
+                tokenAmounts: [
+                    {
+                        assetNameBytes: "74652474436f696e",
+                        amount: "7878754"
+                    },
+                    {
+                        assetNameBytes: "75652474436f696e",
+                        amount: "1234"
+                    }
+                ]
+            }
+        ]
+    }
 };
 
 const SAMPLE_CERTIFICATES = {
@@ -116,6 +144,7 @@ const SAMPLE_WITHDRAWAL = {
 
 const FEE = '42';
 const TTL = '10';
+const VALIDITY_INTERVAL_START = '47';
 
 export default {
     method: 'cardanoSignTransaction',
@@ -359,6 +388,41 @@ export default {
             result: {
                 hash: '47cf79f20c6c62edb4162b3b232a57afc1bd0b57c7fd8389555276408a004776',
                 serializedTx: '83a400818258201af8fa0b754ff99253d983894e63a2b09cbb56c833ba18c3384210163f63dcfc00018382582f82d818582583581cc817d85b524e3d073795819a25cdbb84cff6aa2bbb3a081980d248cba10242182a001a0fb6fc611a002dd2e882581d60cb03849e268f989b5a843107bad7fa2908246986a8f3d643f8c184800182582f82d818582583581c98c3a558f39d1d993cc8770e8825c70a6d0f5a9eb243501c4526c29da10242182a001aa8566c011a000f424002182a030aa1028184582089053545a6c254b0d9b1464e48d2b5fcf91d4e25c128afb1fcfc61d0843338ea5840cc11adf81cb3c3b75a438325f8577666f5cbb4d5d6b73fa6dbbcf5ab36897df34eecacdb54c3bc3ce7fc594ebb2c7aa4db4700f4290facad9b611a035af8710a582026308151516f3b0e02bb1638142747863c520273ce9bd3e5cd91e1d46fe2a63545a10242182af6',
+            },
+        },
+
+        {
+            description: 'signMaryWithValidityIntervalStart',
+            params: {
+                inputs: [SAMPLE_INPUTS['shelley_input']],
+                outputs: [
+                    SAMPLE_OUTPUTS['simple_shelley_output'],
+                ],
+                fee: FEE,
+                validityIntervalStart: VALIDITY_INTERVAL_START,
+                protocolMagic: PROTOCOL_MAGICS['mainnet'],
+                networkId: NETWORK_IDS['mainnet'],
+            },
+            result: {
+                hash: 'ab331c5a1b098763e20cd85aecb65e2364ceb4b35db56e1fb3c36c8d508c9cec',
+                serializedTx: '83a400818258203b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b700018182583901eb0baa5e570cffbe2934db29df0b6a3d7c0430ee65d4c3a7ab2fefb91bc428e4720702ebd5dab4fb175324c192dc9bb76cc5da956e3c8dff0102182a08182fa100818258205d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c15840476b84a2d93c0b1f3f9cc29248ad1e7c11ccd7e2dd69b33e753cb12f52fe57630a1dcc75284a2d863fbbe47df29c0662b62f0498519b77e797b115095095f60ff6',
+            },
+        },
+
+        {
+            description: 'signMaryTokenSending',
+            params: {
+                inputs: [SAMPLE_INPUTS['shelley_input']],
+                outputs: [
+                    SAMPLE_OUTPUTS['token_output'],
+                ],
+                fee: FEE,
+                protocolMagic: PROTOCOL_MAGICS['mainnet'],
+                networkId: NETWORK_IDS['mainnet'],
+            },
+            result: {
+                hash: 'b6cbcb21d6622b81c37a721e37a704524fa4dc10a0b4afc2288c676e8a6ac288',
+                serializedTx: '83a300818258203b40265111d8bb3c3c608d95b3a0bf83461ace32d79336579a1939b3aad1c0b700018182583901eb0baa5e570cffbe2934db29df0b6a3d7c0430ee65d4c3a7ab2fefb91bc428e4720702ebd5dab4fb175324c192dc9bb76cc5da956e3c8dff821a001e8480a2581c95a292ffee938be03e9bae5657982a74e9014eb4960108c9e23a5b39a14874652474436f696e1a00783862581c96a292ffee938be03e9bae5657982a74e9014eb4960108c9e23a5b39a24874652474436f696e1a007838624875652474436f696e1904d202182aa100818258205d010cf16fdeff40955633d6c565f3844a288a24967cf6b76acbeb271b4f13c15840613cf030d3edd562ae1d003e615baa03e41f96f4a470cf854d9588c8da3bcbe09228c064e42eaf101fc4c82fcae1d93cedf160e5465d4f1fd47dd6dacc1cf403f6',
             },
         },
     ],


### PR DESCRIPTION
Motivation: Trezor connect updates needed to support multiasset/validity interval start in Cardano

Depends on https://github.com/vacuumlabs/trezor-firmware/pull/44

Note: based on older commit from connect's develop, namely 966f51d897e7d84cffe169a51aed13fb0377da31 as I was unable to get the integration tests working with custom trezor firmware as they changed the script for that and it no longer seems to have that option, here's the issue I raised without response so far: https://github.com/trezor/connect/issues/723